### PR TITLE
Example plugins

### DIFF
--- a/example_plugins/README.md
+++ b/example_plugins/README.md
@@ -1,0 +1,19 @@
+# Example Plugins
+
+This directory includes a few example plugins for the OpenPathSampling CLI.
+There are various reasons these are not included in the default CLI, including:
+
+* they reproduce existing functionality, and would add confusion to the user
+  experience (`tps.py`)
+* they don't fit into the overall philosophy of the CLI, which intends to
+  provide individual tools instead of "one pot cooking" scripts that do
+  everything in one go (`one_pot_tps.py`).
+
+
+We distribute them here mainly to provide additional examples so
+users/developers can write their own plugins.  Distributing these also makes it
+easy for users to use these specific workflows, without adding confusion for
+all users by making too many commands.
+
+To install a plugin, all you need to do is to copy (or symlink) the file here
+into your `~/.openpathsampling/cli-plugins/` directory.

--- a/example_plugins/one_pot_tps.py
+++ b/example_plugins/one_pot_tps.py
@@ -1,0 +1,49 @@
+import click
+from paths_cli.parameters import (INPUT_FILE, OUTPUT_FILE, ENGINE, STATES,
+                                  N_STEPS_MC, INIT_SNAP)
+from paths_cli.commands.visit_all import visit_all_main
+from paths_cli.commands.equilibrate import equilibrate_main
+from paths_cli.commands.pathsampling import path_sampling_main
+
+
+@click.command("one-pot-tps",
+               short_help="Start from a single frame and end with full TPS")
+@INPUT_FILE.clicked(required=True)
+@OUTPUT_FILE.clicked(required=True)
+@STATES.clicked(required=True)
+@ENGINE.clicked(required=False)
+@click.option("--engine-hot", required=False,
+              help="high temperature engine for initial trajectory")
+@INIT_SNAP.clicked(required=False)
+@N_STEPS_MC
+def one_pot_tps(input_file, output_file, state, nsteps, engine, engine_hot,
+                init_frame):
+    storage = INPUT_FILE.get(input_file)
+    engine = ENGINE.get(storage, engine)
+    engine_hot = engine if engine_hot is None else ENGINE.get(storage,
+                                                              engine_hot)
+    one_pot_tps_main(output_storage=OUTPUT_FILE.get(output_file),
+                     states=STATES.get(storage, state),
+                     engine=engine,
+                     engine_hot=engine_hot,
+                     initial_frame=INIT_SNAP.get(storage, init_frame),
+                     nsteps=nsteps)
+
+
+def one_pot_tps_main(output_storage, states, engine, engine_hot,
+                     initial_frame, nsteps):
+    import openpathsampling as paths
+    network = paths.TPSNetwork.from_states_all_to_all(states)
+    scheme = paths.OneWayShootingMoveScheme(network=network,
+                                            selector=paths.UniformSelector(),
+                                            engine=engine)
+    trajectory, _ = visit_all_main(None, states, engine_hot, initial_frame)
+    equil_multiplier = 1
+    equil_extra = 0
+    equil_set, _ = equilibrate_main(None, scheme, trajectory,
+                                    equil_multiplier, equil_extra)
+    return path_sampling_main(output_storage, scheme, equil_set, nsteps)
+
+CLI = one_pot_tps
+SECTION = "Workflow"
+REQUIRES_OPS = (1, 2)

--- a/example_plugins/tps.py
+++ b/example_plugins/tps.py
@@ -1,0 +1,47 @@
+import click
+from paths_cli.parameters import (
+    INPUT_FILE, OUTPUT_FILE, ENGINE, STATES, INIT_CONDS, N_STEPS_MC
+)
+
+import openpathsampling as paths
+
+@click.command(
+    "tps",
+    short_help="Run transition path sampling simulations",
+)
+@INPUT_FILE.clicked(required=True)
+@OUTPUT_FILE.clicked(required=True)
+@STATES.clicked(required=True)
+@ENGINE.clicked(required=False)
+@INIT_CONDS.clicked(required=False)
+@N_STEPS_MC
+def tps(input_file, engine, state, init_traj, output_file, nsteps):
+    """Run transition path sampling using setup in INPUT_FILE."""
+    storage = INPUT_FILE.get(input_file)
+    tps_main(engine=ENGINE.get(storage, engine),
+             states=[STATES.get(storage, s) for s in state],
+             init_traj=INIT_CONDS.get(storage, init_traj),
+             output_storage=OUTPUT_FILE.get(output_file),
+             n_steps=nsteps)
+
+
+def tps_main(engine, states, init_traj, output_storage, n_steps):
+    network = paths.TPSNetwork(initial_states=states, final_states=states)
+    scheme = paths.OneWayShootingMoveScheme(network, engine=engine)
+    initial_conditions = \
+            scheme.initial_conditions_from_trajectories(init_traj)
+    simulation = paths.PathSampling(
+        storage=output_storage,
+        move_scheme=scheme,
+        sample_set=initial_conditions
+    )
+    simulation.run(n_steps)
+    output_storage.tags['final_conditions'] = simulation.sample_set
+    return simulation.sample_set, simulation
+
+
+CLI = tps
+SECTION = "Simulation"
+
+if __name__ == "__main__":
+    tps()


### PR DESCRIPTION
This adds some example command plugins that we don't normally leave as part of the commands. This includes a `tps` plugin, which simplifies TPS, but reproduces functionality in the `pathsampling` command, and a `one-pot-tps` workflow plugin, which we don't necessarily recommend because it is important to check the initial trajectory.

However, these are things that (1) might be useful for some users; (2) definitely help illustrate how you can write your own plugins.