### PR TITLE
Add --log (logging conf) option to main command

### DIFF
--- a/paths_cli/cli.py
+++ b/paths_cli/cli.py
@@ -4,6 +4,8 @@ This contains the "main" class/functions for running the OPS CLI.
 """
 # builds off the example of MultiCommand in click's docs
 import collections
+import logging
+import logging.config
 import os
 
 import click
@@ -36,15 +38,29 @@ class OpenPathSamplingCLI(click.MultiCommand):
                 self.plugin_folders.append(folder)
 
         plugin_files = self._list_plugin_files(self.plugin_folders)
-        self.plugins = self._load_plugin_files(plugin_files)
+        plugins = self._load_plugin_files(plugin_files)
 
         self._get_command = {}
         self._sections = collections.defaultdict(list)
-        for plugin in self.plugins:
-            self._get_command[plugin.name] = plugin.func
-            self._sections[plugin.section].append(plugin.name)
+        self.plugins = []
+        for plugin in plugins:
+            self._register_plugin(plugin)
 
         super(OpenPathSamplingCLI, self).__init__(*args, **kwargs)
+
+    def _register_plugin(self, plugin):
+        self.plugins.append(plugin)
+        self._get_command[plugin.name] = plugin.func
+        self._sections[plugin.section].append(plugin.name)
+
+    def _deregister_plugin(self, plugin):
+        # mainly used in testing
+        self.plugins.remove(plugin)
+        del self._get_command[plugin.name]
+        self._sections[plugin.section].remove(plugin.name)
+
+    def plugin_for_command(self, command_name):
+        return {p.name: p for p in self.plugins}[name]
 
     @staticmethod
     def _list_plugin_files(plugin_folders):
@@ -118,16 +134,18 @@ tool with:
     openpathsampling strip-snapshots --help
 """
 
-OPS_CLI = OpenPathSamplingCLI(
-    name="openpathsampling",
-    help=_MAIN_HELP,
-    context_settings=CONTEXT_SETTINGS
-)
+@click.command(cls=OpenPathSamplingCLI, name="openpathsampling",
+               help=_MAIN_HELP, context_settings=CONTEXT_SETTINGS)
+@click.option('--log', type=click.Path(exists=True, readable=True),
+              help="logging configuration file")
+def main(log):
+    if log:
+        logging.config.fileConfig(log, disable_existing_loggers=False)
+    # TODO: if log not given, check for logging.conf in .openpathsampling/
 
-def main():  # no-cov
-    OPS_CLI()
-
+    logger = logging.getLogger(__name__)
+    logger.debug("About to run command")  # TODO: maybe log invocation?
+    pass
 
 if __name__ == '__main__':  # no-cov
-    main()
-    # print("list commands:", cli.list_commands())
+    cli()

--- a/paths_cli/cli.py
+++ b/paths_cli/cli.py
@@ -145,7 +145,6 @@ def main(log):
 
     logger = logging.getLogger(__name__)
     logger.debug("About to run command")  # TODO: maybe log invocation?
-    pass
 
 if __name__ == '__main__':  # no-cov
     cli()

--- a/paths_cli/tests/null_command.py
+++ b/paths_cli/tests/null_command.py
@@ -1,10 +1,12 @@
+import logging
 import click
 @click.command(
     'null-command',
     short_help="Do nothing (testing)"
 )
 def null_command():
-    print("Running null command")
+    logger = logging.getLogger(__name__)
+    logger.info("Running null command")
 
 CLI = null_command
 SECTION = "Workflow"

--- a/paths_cli/tests/null_command.py
+++ b/paths_cli/tests/null_command.py
@@ -1,0 +1,22 @@
+import click
+@click.command(
+    'null-command',
+    short_help="Do nothing (testing)"
+)
+def null_command():
+    print("Running null command")
+
+CLI = null_command
+SECTION = "Workflow"
+
+class NullCommandContext(object):
+    """Context that registers/deregisters the null command (for tests)"""
+    def __init__(self, cli):
+        self.plugin = cli._load_plugin_files([__file__])[0]
+        self.cli = cli
+
+    def __enter__(self):
+        self.cli._register_plugin(self.plugin)
+
+    def __exit__(self, type, value, traceback):
+        self.cli._deregister_plugin(self.plugin)

--- a/paths_cli/tests/test_cli.py
+++ b/paths_cli/tests/test_cli.py
@@ -46,7 +46,7 @@ def test_main_log(with_log):
     }[with_log]
     expected = {
         True: logged_stdout + cmd_stdout,
-        False: cmd_stdout
+        False: ""
     }[with_log]
     with runner.isolated_filesystem():
         with open("logging.conf", mode='w') as log_conf:

--- a/paths_cli/tests/test_cli.py
+++ b/paths_cli/tests/test_cli.py
@@ -1,0 +1,58 @@
+import pytest
+from click.testing import CliRunner
+
+import logging
+
+from paths_cli.cli import *
+from .null_command import NullCommandContext
+
+class TestOpenPathSamplingCLI(object):
+    def setup(self):
+        # TODO: patch out the directory to fake the plugins
+        self.cli = OpenPathSamplingCLI()
+
+    def test_plugins(self):
+        pytest.skip()
+        pass
+
+    def test_get_command(self):
+        # test renamings
+        pytest.skip()
+        pass
+
+    def test_format_commands(self):
+        pytest.skip()
+        # use a mock to get the formatter
+        # test that it skips a section if it is empty
+        pass
+
+@pytest.mark.parametrize('with_log', [True, False])
+def test_main_log(with_log):
+    logged_stdout = "About to run command\n"
+    cmd_stdout = "Running null command\n"
+    logfile_text = "\n".join([
+        "[loggers]", "keys=root", "",
+        "[handlers]", "keys=std", "",
+        "[formatters]", "keys=default", "",
+        "[formatter_default]", "format=%(message)s", "",
+        "[handler_std]", "class=StreamHandler", "level=NOTSET",
+        "formatter=default", "args=(sys.stdout,)", ""
+        "[logger_root]", "level=DEBUG", "handlers=std"
+    ])
+    runner = CliRunner()
+    invocation = {
+        True: ['--log', 'logging.conf', 'null-command'],
+        False: ['null-command']
+    }[with_log]
+    expected = {
+        True: logged_stdout + cmd_stdout,
+        False: cmd_stdout
+    }[with_log]
+    with runner.isolated_filesystem():
+        with open("logging.conf", mode='w') as log_conf:
+            log_conf.write(logfile_text)
+
+        with NullCommandContext(main):
+            result = runner.invoke(main, invocation)
+    found = result.stdout_bytes
+    assert found.decode('utf-8') == expected


### PR DESCRIPTION
This will add the `--log` option, which takes a Python logging configuration file, to the main command. 

Usage would be like this:

```
openpathsampling --log logging.conf pathsampling setup.nc -o output.nc -n 1000
```

Note that the `--log` option comes *before* the command.