### PR TITLE
Update plugin management approach

### DIFF
--- a/devtools/miniconda_install.sh
+++ b/devtools/miniconda_install.sh
@@ -22,7 +22,7 @@ conda_version="latest"
 #conda_version="4.4.10"  # can pin a miniconda version like this, if needed
 
 MINICONDA=Miniconda${pyV}-${conda_version}-${OS_ARCH}.sh
-MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
+MINICONDA_MD5=$(curl -sL https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
 wget https://repo.continuum.io/miniconda/$MINICONDA
 SCRIPT_MD5=`eval "$MD5_CMD $MD5_OPT $MINICONDA" | cut -d ' ' -f 1`
 

--- a/paths_cli/cli.py
+++ b/paths_cli/cli.py
@@ -17,13 +17,6 @@ from .plugin_management import FilePluginLoader, NamespacePluginLoader
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
-_POSSIBLE_PLUGIN_FOLDERS = [
-    os.path.join(os.path.dirname(__file__), 'commands'),
-    os.path.join(click.get_app_dir("OpenPathSampling"), 'cli-plugins'),
-    os.path.join(click.get_app_dir("OpenPathSampling", force_posix=True),
-                 'cli-plugins'),
-]
-
 class OpenPathSamplingCLI(click.MultiCommand):
     """Main class for the command line interface
 

--- a/paths_cli/cli.py
+++ b/paths_cli/cli.py
@@ -7,10 +7,13 @@ import collections
 import logging
 import logging.config
 import os
+import pathlib
 
 import click
 # import click_completion
 # click_completion.init()
+
+from .plugin_management import FilePluginLoader, NamespacePluginLoader
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
@@ -21,10 +24,6 @@ _POSSIBLE_PLUGIN_FOLDERS = [
                  'cli-plugins'),
 ]
 
-OPSPlugin = collections.namedtuple("OPSPlugin",
-                                   ['name', 'filename', 'func', 'section'])
-
-
 class OpenPathSamplingCLI(click.MultiCommand):
     """Main class for the command line interface
 
@@ -32,13 +31,20 @@ class OpenPathSamplingCLI(click.MultiCommand):
     """
     def __init__(self, *args, **kwargs):
         # the logic here is all about loading the plugins
-        self.plugin_folders = []
-        for folder in _POSSIBLE_PLUGIN_FOLDERS:
-            if folder not in self.plugin_folders and os.path.exists(folder):
-                self.plugin_folders.append(folder)
+        commands = str(pathlib.Path(__file__).parent.resolve() / 'commands')
+        def app_dir_plugins(posix):
+            return str(pathlib.Path(
+                click.get_app_dir("OpenPathSampling", force_posix=posix)
+            ).resolve() / 'cli-plugins')
 
-        plugin_files = self._list_plugin_files(self.plugin_folders)
-        plugins = self._load_plugin_files(plugin_files)
+        self.plugin_loaders = [
+            FilePluginLoader(commands),
+            FilePluginLoader(app_dir_plugins(posix=False)),
+            FilePluginLoader(app_dir_plugins(posix=True)),
+            NamespacePluginLoader('paths_cli.plugins')
+        ]
+
+        plugins = sum([loader() for loader in self.plugin_loaders], [])
 
         self._get_command = {}
         self._sections = collections.defaultdict(list)
@@ -61,45 +67,6 @@ class OpenPathSamplingCLI(click.MultiCommand):
 
     def plugin_for_command(self, command_name):
         return {p.name: p for p in self.plugins}[command_name]
-
-    @staticmethod
-    def _list_plugin_files(plugin_folders):
-        def is_plugin(filename):
-            return (
-                filename.endswith(".py") and not filename.startswith("_")
-                and not filename.startswith(".")
-            )
-
-        plugin_files = []
-        for folder in plugin_folders:
-            files = [os.path.join(folder, f) for f in os.listdir(folder)
-                     if is_plugin(f)]
-            plugin_files += files
-        return plugin_files
-
-    @staticmethod
-    def _filename_to_command_name(filename):
-        command_name = filename[:-3]  # get rid of .py
-        command_name = command_name.replace('_', '-')  # commands use -
-        return command_name
-
-    @staticmethod
-    def _load_plugin(name):
-        ns = {}
-        with open(name) as f:
-            code = compile(f.read(), name, 'exec')
-            eval(code, ns, ns)
-        return ns['CLI'], ns['SECTION']
-
-    def _load_plugin_files(self, plugin_files):
-        plugins = []
-        for full_name in plugin_files:
-            _, filename = os.path.split(full_name)
-            command_name = self._filename_to_command_name(filename)
-            func, section = self._load_plugin(full_name)
-            plugins.append(OPSPlugin(name=command_name, filename=full_name,
-                                     func=func, section=section))
-        return plugins
 
     def list_commands(self, ctx):
         return list(self._get_command.keys())

--- a/paths_cli/plugin_management.py
+++ b/paths_cli/plugin_management.py
@@ -1,0 +1,126 @@
+import collections
+import pkgutil
+import importlib
+import os
+
+OPSPlugin = collections.namedtuple(
+    "OPSPlugin", ['name', 'location', 'func', 'section', 'plugin_type']
+)
+
+class CLIPluginLoader(object):
+    """Abstract object for CLI plugins
+
+    The overall approach involves 5 steps, each of which can be overridden:
+
+    1. Find candidate plugins (which must be Python modules)
+    2. Load the namespaces associated into a dict (nsdict)
+    3. Based on those namespaces, validate that the module *is* a plugin
+    4. Get the associated command name
+    5. Return an OPSPlugin object for each plugin
+
+    Details on steps 1, 2, and 4 differ based on whether this is a
+    filesystem-based plugin or a namespace-based plugin.
+    """
+    def __init__(self, plugin_type, search_path):
+        self.plugin_type = plugin_type
+        self.search_path = search_path
+
+    def _find_candidates(self):
+        raise NotImplementedError()
+
+    @staticmethod
+    def _make_nsdict(candidate):
+        raise NotImplementedError()
+
+    @staticmethod
+    def _validate(nsdict):
+        for attr in ['CLI', 'SECTION']:
+            if attr not in nsdict:
+                return False
+        return True
+
+    def _get_command_name(self, candidate):
+        raise NotImplementedError()
+
+    def _find_valid(self):
+        candidates = self._find_candidates()
+        namespaces = {cand: self._make_nsdict(cand) for cand in candidates}
+        valid = {cand: ns for cand, ns in namespaces.items()
+                 if self._validate(ns)}
+        return valid
+
+    def __call__(self):
+        valid = self._find_valid()
+        plugins = [
+            OPSPlugin(name=self._get_command_name(cand),
+                      location=cand,
+                      func=ns['CLI'],
+                      section=ns['SECTION'],
+                      plugin_type=self.plugin_type)
+            for cand, ns in valid.items()
+        ]
+        return plugins
+
+
+class FilePluginLoader(CLIPluginLoader):
+    """File-based plugins (quick and dirty)
+    """
+    def __init__(self, search_path):
+        super().__init__(plugin_type="file", search_path=search_path)
+
+    def _find_candidates(self):
+        def is_plugin(filename):
+            return (
+                filename.endswith(".py") and not filename.startswith("_")
+                and not filename.startswith(".")
+            )
+        candidates = [os.path.join(self.search_path, f)
+                      for f in os.listdir(self.search_path)
+                      if is_plugin(f)]
+        return candidates
+
+    @staticmethod
+    def _make_nsdict(candidate):
+        ns = {}
+        with open(candidate) as f:
+            code = compile(f.read(), candidate, 'exec')
+            eval(code, ns, ns)
+        return ns
+
+    def _get_command_name(self, candidate):
+        _, command_name = os.path.split(candidate)
+        command_name = command_name[:-3]  # get rid of .py
+        command_name = command_name.replace('_', '-')  # commands use -
+        return command_name
+
+
+class NamespacePluginLoader(CLIPluginLoader):
+    """Load namespace plugins (plugins for wide distribution)
+    """
+    def __init__(self, search_path):
+        super().__init__(plugin_type="namespace", search_path=search_path)
+
+    def _find_candidates(self):
+        # based on https://packaging.python.org/guides/creating-and-discovering-plugins/#using-namespace-packages
+        def iter_namespace(ns_pkg):
+            return pkgutil.iter_modules(ns_pkg.__path__,
+                                        ns_pkg.__name__ + ".")
+
+        ns = importlib.import_module(self.search_path)
+        candidates = [
+            importlib.import_module(name)
+            for _, name, _ in iter_namespace(ns)
+        ]
+        return candidates
+
+    @staticmethod
+    def _make_nsdict(candidate):
+        return vars(candidate)
+
+    def _get_command_name(self, candidate):
+        # +1 for the dot
+        command_name = candidate.__name__
+        command_name = command_name[len(self.search_path) + 1:]
+        command_name = command_name.replace('_', '-')  # commands use -
+        return command_name
+

--- a/paths_cli/plugin_management.py
+++ b/paths_cli/plugin_management.py
@@ -79,6 +79,10 @@ class FilePluginLoader(CLIPluginLoader):
                 filename.endswith(".py") and not filename.startswith("_")
                 and not filename.startswith(".")
             )
+
+        if not os.path.exists(os.path.join(self.search_path)):
+            return []
+
         candidates = [os.path.join(self.search_path, f)
                       for f in os.listdir(self.search_path)
                       if is_plugin(f)]

--- a/paths_cli/plugin_management.py
+++ b/paths_cli/plugin_management.py
@@ -64,6 +64,11 @@ class CLIPluginLoader(object):
 
 class FilePluginLoader(CLIPluginLoader):
     """File-based plugins (quick and dirty)
+
+    Parameters
+    ----------
+    search_path : str
+        path to the directory that contains plugins (OS-dependent format)
     """
     def __init__(self, search_path):
         super().__init__(plugin_type="file", search_path=search_path)
@@ -96,6 +101,11 @@ class FilePluginLoader(CLIPluginLoader):
 
 class NamespacePluginLoader(CLIPluginLoader):
     """Load namespace plugins (plugins for wide distribution)
+
+    Parameters
+    ----------
+    search_path : str
+        namespace (dot-separated) where plugins can be found
     """
     def __init__(self, search_path):
         super().__init__(plugin_type="namespace", search_path=search_path)

--- a/paths_cli/tests/null_command.py
+++ b/paths_cli/tests/null_command.py
@@ -1,5 +1,8 @@
 import logging
 import click
+
+from paths_cli.plugin_management import FilePluginLoader, OPSPlugin
+
 @click.command(
     'null-command',
     short_help="Do nothing (testing)"
@@ -14,7 +17,13 @@ SECTION = "Workflow"
 class NullCommandContext(object):
     """Context that registers/deregisters the null command (for tests)"""
     def __init__(self, cli):
-        self.plugin = cli._load_plugin_files([__file__])[0]
+        self.plugin = OPSPlugin(name="null-command",
+                                location=__file__,
+                                func=CLI,
+                                section=SECTION,
+                                plugin_type="file")
+
+        cli._register_plugin(self.plugin)
         self.cli = cli
 
     def __enter__(self):

--- a/paths_cli/tests/test_cli.py
+++ b/paths_cli/tests/test_cli.py
@@ -31,8 +31,10 @@ class TestOpenPathSamplingCLI(object):
         }
         self.plugins = list(self.plugin_dict.values())
         self.cli = OpenPathSamplingCLI()
-        for plugin in self.cli.plugins:
+        # need to copy the plugins since we're changing the list
+        for plugin in self.cli.plugins[:]:
             self.cli._deregister_plugin(plugin)
+
         for plugin in self.plugins:
             self.cli._register_plugin(plugin)
 

--- a/paths_cli/tests/test_plugin_management.py
+++ b/paths_cli/tests/test_plugin_management.py
@@ -1,0 +1,113 @@
+import pytest
+from unittest.mock import MagicMock
+
+import pathlib
+import importlib
+
+import paths_cli
+from paths_cli.plugin_management import *
+
+# need to check that CLI is assigned to correct type
+import click
+
+class TestCLIPluginLoader(object):
+    def setup(self):
+        class MockPlugin(object):
+            def get_dict(self):
+                return {
+                    'CLI': self.foo,
+                    'SECTION': "FooSection"
+                }
+
+            def foo():
+                pass
+
+        self.plugin = MockPlugin()
+        self.loader = CLIPluginLoader(plugin_type="test", search_path="foo")
+        self.loader._make_nsdict = MockPlugin.get_dict
+        self.loader._find_candidates = MagicMock(return_value=[self.plugin])
+
+    @pytest.mark.parametrize('contains', ([], ['cli'], ['sec'],
+                                          ['cli', 'sec']))
+    def test_validate(self, contains):
+        expected = len(contains) == 2  # only case where we expect correct
+        dct = {'cli': self.plugin.foo, 'sec': "FooSection"}
+        fullnames = {'cli': "CLI", 'sec': "SECTION"}
+        nsdict = {fullnames[obj]: dct[obj] for obj in contains}
+
+        assert CLIPluginLoader._validate(nsdict) == expected
+
+    def test_find_valid(self):
+        # smoke test for the procedure
+        expected = {self.plugin: self.plugin.get_dict()}
+        assert self.loader._find_valid() == expected
+
+
+class PluginLoaderTest(object):
+    def setup(self):
+        self.expected_section = {'pathsampling': "Simulation",
+                                 'contents': "Miscellaneous"}
+
+    def _make_candidate(self, command):
+        raise NotImplementedError()
+
+    @pytest.mark.parametrize('command', ['pathsampling', 'contents'])
+    def test_find_candidates(self, command):
+        candidates  = self.loader._find_candidates()
+        str_candidates = str([c for c in candidates])
+        assert str(self._make_candidate(command)) in str_candidates
+
+    @pytest.mark.parametrize('command', ['pathsampling', 'contents'])
+    def test_make_nsdict(self, command):
+        candidate = self._make_candidate(command)
+        nsdict = self.loader._make_nsdict(candidate)
+        assert nsdict['SECTION'] == self.expected_section[command]
+        assert isinstance(nsdict['CLI'], click.Command)
+
+    @pytest.mark.parametrize('command', ['pathsampling', 'contents'])
+    def test_call(self, command):
+        plugins = self.loader()
+        plugin_dict = {p.name: p for p in plugins}
+        plugin = plugin_dict[command]
+        assert plugin.name == command
+        assert str(plugin.location) == str(self._make_candidate(command))
+        assert isinstance(plugin.func, click.Command)
+        assert plugin.section == self.expected_section[command]
+        assert plugin.plugin_type == self.plugin_type
+
+
+class TestFilePluginLoader(PluginLoaderTest):
+    def setup(self):
+        super().setup()
+        # use our own commands dir as a file-based plugin
+        cmds_init = pathlib.Path(paths_cli.commands.__file__).resolve()
+        self.commands_dir = cmds_init.parent
+        self.loader = FilePluginLoader(self.commands_dir)
+        self.plugin_type = 'file'
+
+    def _make_candidate(self, command):
+        return self.commands_dir / (command + ".py")
+
+    def test_get_command_name(self):
+        # this may someday get parametrized, set it up to make it easy
+        filename = "/foo/bar/baz_qux.py"
+        expected = "baz-qux"
+        assert self.loader._get_command_name(filename) == expected
+
+
+class TestNamespacePluginLoader(PluginLoaderTest):
+    def setup(self):
+        super().setup()
+        self.namespace = "paths_cli.commands"
+        self.loader = NamespacePluginLoader(self.namespace)
+        self.plugin_type = 'namespace'
+
+    def _make_candidate(self, command):
+        name = self.namespace + "." + command
+        return importlib.import_module(name)
+
+    def test_get_command_name(self):
+        loader = NamespacePluginLoader('foo.bar')
+        candidate = MagicMock(__name__="foo.bar.baz_qux")
+        expected = "baz-qux"
+        assert loader._get_command_name(candidate) == expected

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = openpathsampling-cli
-version = 0.0.3.dev0
+version = 0.0.4.dev0
 # version should end in .dev0 if this isn't to be released
 description = Command line tool for OpenPathSampling
 long_description = file: README.md


### PR DESCRIPTION
This new approach will include two different ways to create OPS plugins. The key difference is in how plugins are discovered:

1. "File plugins": This is the same functionality that has already been implemented: search specific directories for files that can be used as plugins.
2. "Namespace package plugins": This approach is basically described in https://packaging.python.org/guides/creating-and-discovering-plugins/#using-namespace-packages. We'll expect [native namespace packages](https://packaging.python.org/guides/packaging-namespace-packages/#native-namespace-packages).

"File plugins" are suitable as a quick-and-dirty approach for yourself or for small-scale sharing. "Namespace package plugins" take a little more work, but are more suitable to be widely distributed.

This PR will include support and testing for both plugin types.