### PR TITLE
Release 0.1

### DIFF
--- a/paths_cli/file_copying.py
+++ b/paths_cli/file_copying.py
@@ -17,6 +17,7 @@ INPUT_APPEND_FILE = StorageLoader(
     mode='a'
 )
 
+
 class PrecomputeLoadNames(OPSStorageLoadNames):
     def get(self, storage, name):
         if len(name) == 0:
@@ -25,6 +26,7 @@ class PrecomputeLoadNames(OPSStorageLoadNames):
             return []
 
         return super(PrecomputeLoadNames, self).get(storage, name)
+
 
 PRECOMPUTE_CVS = PrecomputeLoadNames(
     param=Option('--cv', type=str, multiple=True,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = openpathsampling-cli
-version = 0.0.4.dev0
+version = 0.1.0
 # version should end in .dev0 if this isn't to be released
 description = Command line tool for OpenPathSampling
 long_description = file: README.md
@@ -22,7 +22,7 @@ python_requires = >= 3.6
 install_requires =
     click
     tqdm
-    openpathsampling
+    openpathsampling >= 1.2
 packages = find:
 
 [options.entry_points]


### PR DESCRIPTION
OpenPathSampling-CLI 0.1 is ready for users!

We're starting out with only a few commands; see the [readme file](https://github.com/openpathsampling/openpathsampling-cli#readme) for an overview, or the [documentation](https://openpathsampling-cli.readthedocs.io/en/latest/) for details (particularly aimed at developers.)

This release provides an improved plugin management approach over what was available in 0.0.3, and brings test coverage to 100%.

## Enhancements
* Update plugin management approach (#19)

## Miscellaneous improvements
* Switch to CodeCov; bump autorelease travis (#23)
* Command tests (#22)