### PR TITLE
Add  --table option in `contents`

### DIFF
--- a/paths_cli/commands/contents.py
+++ b/paths_cli/commands/contents.py
@@ -1,13 +1,8 @@
 import click
 from paths_cli.parameters import INPUT_FILE
 
-UNNAMED_SECTIONS = {
-    'Steps': lambda storage: storage.steps,
-    'Move Changes': lambda storage: storage.movechanges,
-    'SampleSets': lambda storage: storage.samplesets,
-    'Trajectories': lambda storage: storage.trajectories,
-    'Snapshots': lambda storage: storage.snapshots
-}
+UNNAMED_SECTIONS = ['steps', 'movechanges', 'samplesets', 'trajectories',
+                    'snapshots']
 
 @click.command(
     'contents',
@@ -52,7 +47,15 @@ def report_all_tables(storage):
     print(get_section_string_nameable('Tags', storage.tags, _get_named_tags))
 
     print("\nData Objects:")
-    for section, store_func in UNNAMED_SECTIONS.items():
+    data_object_mapping = {
+        'Steps': lambda storage: storage.steps,
+        'Move Changes': lambda storage: storage.movechanges,
+        'SampleSets': lambda storage: storage.samplesets,
+        'Trajectories': lambda storage: storage.trajectories,
+        'Snapshots': lambda storage: storage.snapshots
+    }
+
+    for section, store_func in data_object_mapping.items():
         store = store_func(storage)
         print(get_unnamed_section_string(section, store))
 

--- a/paths_cli/commands/contents.py
+++ b/paths_cli/commands/contents.py
@@ -4,6 +4,21 @@ from paths_cli.parameters import INPUT_FILE
 UNNAMED_SECTIONS = ['steps', 'movechanges', 'samplesets', 'trajectories',
                     'snapshots']
 
+NAME_TO_ATTR = {
+    'CVs': 'cvs',
+    'Volumes': 'volumes',
+    'Engines': 'engines',
+    'Networks': 'networks',
+    'Move Schemes': 'schemes',
+    'Simulations': 'pathsimulators',
+    'Tags': 'tags',
+    'Steps': 'steps',
+    'Move Changes': 'movechanges',
+    'SampleSets': 'samplesets',
+    'Trajectories': 'trajectories',
+    'Snapshots': 'snapshots'
+}
+
 @click.command(
     'contents',
     short_help="list named objects from an OPS .nc file",
@@ -26,13 +41,22 @@ def contents(input_file, table):
         try:
             store = getattr(storage, table_attr)
         except AttributeError:
-            print("This needs to raise a good error; bad table name")
+            raise click.UsageError("Unknown table: '" + table_attr + "'")
         else:
-            if table_attr in UNNAMED_SECTIONS:
-                print(get_unnamed_section_string(table_attr, store))
-            else:
-                print(get_section_string_nameable(table_attr, store,
-                                                  _get_named_namedobj))
+            print(get_section_string(table_attr, store))
+
+
+def get_section_string(label, store):
+    attr = NAME_TO_ATTR.get(label, label.lower())
+    if attr in UNNAMED_SECTIONS:
+        string = get_unnamed_section_string(label, store)
+    elif attr in ['tag', 'tags']:
+        string = get_section_string_nameable(label, store, _get_named_tags)
+    else:
+        string = get_section_string_nameable(label, store,
+                                             _get_named_namedobj)
+    return string
+
 
 def report_all_tables(storage):
     store_section_mapping = {

--- a/paths_cli/commands/contents.py
+++ b/paths_cli/commands/contents.py
@@ -1,12 +1,22 @@
 import click
 from paths_cli.parameters import INPUT_FILE
 
+UNNAMED_SECTIONS = {
+    'Steps': lambda storage: storage.steps,
+    'Move Changes': lambda storage: storage.movechanges,
+    'SampleSets': lambda storage: storage.samplesets,
+    'Trajectories': lambda storage: storage.trajectories,
+    'Snapshots': lambda storage: storage.snapshots
+}
+
 @click.command(
     'contents',
     short_help="list named objects from an OPS .nc file",
 )
 @INPUT_FILE.clicked(required=True)
-def contents(input_file):
+@click.option('--table', type=str, required=False,
+              help="table to show results from")
+def contents(input_file, table):
     """List the names of named objects in an OPS .nc file.
 
     This is particularly useful when getting ready to use one of simulation
@@ -14,6 +24,22 @@ def contents(input_file):
     """
     storage = INPUT_FILE.get(input_file)
     print(storage)
+    if table is None:
+        report_all_tables(storage)
+    else:
+        table_attr = table.lower()
+        try:
+            store = getattr(storage, table_attr)
+        except AttributeError:
+            print("This needs to raise a good error; bad table name")
+        else:
+            if table_attr in UNNAMED_SECTIONS:
+                print(get_unnamed_section_string(table_attr, store))
+            else:
+                print(get_section_string_nameable(table_attr, store,
+                                                  _get_named_namedobj))
+
+def report_all_tables(storage):
     store_section_mapping = {
         'CVs': storage.cvs, 'Volumes': storage.volumes,
         'Engines': storage.engines, 'Networks': storage.networks,
@@ -26,12 +52,8 @@ def contents(input_file):
     print(get_section_string_nameable('Tags', storage.tags, _get_named_tags))
 
     print("\nData Objects:")
-    unnamed_sections = {
-        'Steps': storage.steps, 'Move Changes': storage.movechanges,
-        'SampleSets': storage.samplesets,
-        'Trajectories': storage.trajectories, 'Snapshots': storage.snapshots
-    }
-    for section, store in unnamed_sections.items():
+    for section, store_func in UNNAMED_SECTIONS.items():
+        store = store_func(storage)
         print(get_unnamed_section_string(section, store))
 
 def _item_or_items(count):

--- a/paths_cli/tests/commands/test_contents.py
+++ b/paths_cli/tests/commands/test_contents.py
@@ -41,7 +41,7 @@ def test_contents(tps_fixture):
         for truth, beauty in zip(expected, results.output.split('\n')):
             assert truth == beauty
 
-@pytest.mark.parametrize('table', ['volumes', 'trajectories'])
+@pytest.mark.parametrize('table', ['volumes', 'trajectories', 'tags'])
 def test_contents_table(tps_fixture, table):
     scheme, network, engine, init_conds = tps_fixture
     runner = CliRunner()
@@ -63,7 +63,13 @@ def test_contents_table(tps_fixture, table):
                 f"Storage @ '{cwd}/setup.nc'",
                 "trajectories: 1 unnamed item",
                 ""
-            ]
+            ],
+            'tags': [
+                f"Storage @ '{cwd}/setup.nc'",
+                "tags: 1 item",
+                "* initial_conditions",
+                ""
+            ],
         }[table]
         assert results.output.split("\n") == expected
         assert results.exit_code == 0

--- a/paths_cli/tests/commands/test_contents.py
+++ b/paths_cli/tests/commands/test_contents.py
@@ -67,3 +67,11 @@ def test_contents_table(tps_fixture, table):
         }[table]
         assert results.output.split("\n") == expected
         assert results.exit_code == 0
+
+def test_contents_table_error():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        storage = paths.Storage("temp.nc", mode='w')
+        storage.close()
+        results = runner.invoke(contents, ['temp.nc', '--table', 'foo'])
+        assert results.exit_code != 0


### PR DESCRIPTION
This allows users to only load a specific table with the `contents` subcommand. Not only does this allow one to cut down on clutter, but there are some tables that are not shown in the normal `contents` command. Example:

```
$ openpathsampling contents mstis.nc --table ensembles
Storage @ '/Users/dwhs/ops_tutorial/mstis.nc'
ensembles: 218 items
* Out A 0
* Out A 2
* Out B 1
* Out B 2
* Out C 0
* Out C 2
* Out C 1
* Out B 0
* Out A 1
* Out A minus
* Out B minus
* Out C minus
* plus 206 unnamed items
```