### PR TITLE
Allow multiple uses of --init-conds

### DIFF
--- a/paths_cli/commands/equilibrate.py
+++ b/paths_cli/commands/equilibrate.py
@@ -43,6 +43,7 @@ def equilibrate_main(output_storage, scheme, init_conds, multiplier,
                      extra_steps):
     import openpathsampling as paths
     init_conds = scheme.initial_conditions_from_trajectories(init_conds)
+    scheme.assert_initial_conditions(init_conds)
     simulation = paths.PathSampling(
         storage=output_storage,
         move_scheme=scheme,

--- a/paths_cli/param_core.py
+++ b/paths_cli/param_core.py
@@ -273,3 +273,51 @@ class OPSStorageLoadSingle(AbstractLoader):
             raise RuntimeError("Couldn't find %s", name)
 
         return result
+
+
+class OPSStorageLoadMultiple(OPSStorageLoadSingle):
+    """Objects that can guess a single object or have multiple specified.
+
+    Parameters
+    ----------
+    param : :class:`.AbstractParameter`
+        the Option or Argument wrapping a click decorator
+    store : Str
+        the name of the store to search
+    value_strategies : List[Callable[(:class:`.Storage`, Str), Any]]
+        The strategies to be used when the CLI provides a value for this
+        parameter. Each should be a callable taking a storage and the string
+        input from the CLI, and should return the desired object or None if
+        it cannot be found.
+    none_strategies : List[Callable[:class:`openpathsampling.Storage, Any]]
+        The strategies to be used when the CLI does not provide a value for
+        this parameter. Each should be a callable taking a storage, and
+        returning the desired object or None if it cannot be found.
+    """
+    def get(self, storage, names):
+        """Load desired objects from storage.
+
+        Parameters
+        ----------
+        storage : openpathsampling.Storage
+            the input storage to search
+        names : List[Str] or None
+            strings from CLI providing the identifier (name or index) for
+            this object; None if not provided
+        """
+        if names == tuple():
+            names = None
+
+        if names is None or isinstance(names, (str, int)):
+            listified = True
+            names = [names]
+        else:
+            listified = False
+
+        results = [super(OPSStorageLoadMultiple, self).get(storage, name)
+                   for name in names]
+
+        if listified:
+            results = results[0]
+
+        return results

--- a/paths_cli/parameters.py
+++ b/paths_cli/parameters.py
@@ -19,9 +19,9 @@ SCHEME = OPSStorageLoadSingle(
 )
 
 INIT_CONDS = OPSStorageLoadSingle(
-    param=Option('-t', '--init-conds',
+    param=Option('-t', '--init-conds', multiple=True,
                  help=("identifier for initial conditions "
-                       + "(sample set or trajectory)")),
+                       + "(sample set or trajectory)" + HELP_MULTIPLE)),
     store='samplesets',
     value_strategies=[GetByName('tags'), GetByNumber('samplesets'),
                       GetByNumber('trajectories')],
@@ -56,7 +56,6 @@ MULTI_ENGINE = OPSStorageLoadNames(
                  help='name or index of engine' + HELP_MULTIPLE),
     store='engines'
 )
-
 
 STATES = OPSStorageLoadNames(
     param=Option('-s', '--state', type=str, multiple=True,

--- a/paths_cli/parameters.py
+++ b/paths_cli/parameters.py
@@ -1,8 +1,8 @@
 import click
 from paths_cli.param_core import (
-    Option, Argument, OPSStorageLoadSingle, OPSStorageLoadNames,
-    StorageLoader, GetByName, GetByNumber, GetOnly, GetOnlySnapshot,
-    GetPredefinedName
+    Option, Argument, OPSStorageLoadSingle, OPSStorageLoadMultiple,
+    OPSStorageLoadNames, StorageLoader, GetByName, GetByNumber, GetOnly,
+    GetOnlySnapshot, GetPredefinedName
 )
 
 
@@ -18,7 +18,7 @@ SCHEME = OPSStorageLoadSingle(
     store='schemes',
 )
 
-INIT_CONDS = OPSStorageLoadSingle(
+INIT_CONDS = OPSStorageLoadMultiple(
     param=Option('-t', '--init-conds', multiple=True,
                  help=("identifier for initial conditions "
                        + "(sample set or trajectory)" + HELP_MULTIPLE)),

--- a/paths_cli/tests/commands/test_pathsampling.py
+++ b/paths_cli/tests/commands/test_pathsampling.py
@@ -26,10 +26,11 @@ def test_pathsampling(tps_fixture):
 
         results = runner.invoke(pathsampling, ['setup.nc', '-o', 'foo.nc',
                                                '-n', '1000'])
-        assert results.exit_code == 0
         expected_output = (f"True\n{scheme.__uuid__}\n{init_conds.__uuid__}"
                            "\n1000\n")
+
         assert results.output == expected_output
+        assert results.exit_code == 0
 
 
 def test_pathsampling_main(tps_fixture):

--- a/paths_cli/tests/test_parameters.py
+++ b/paths_cli/tests/test_parameters.py
@@ -234,6 +234,14 @@ class TestINIT_CONDS(ParamInstanceTest):
         obj = INIT_CONDS.get(st, None)
         assert obj == stored_things[num_in_file - 1]
 
+    def test_get_multiple(self):
+        filename = self.create_file('number-traj')
+        storage = paths.Storage(filename, mode='r')
+        traj0, traj1 = self.PARAMETER.get(storage, (0, 1))
+        assert traj0 == self.traj
+        assert traj1 == self.other_traj
+
+
 class TestINIT_SNAP(ParamInstanceTest):
     PARAMETER = INIT_SNAP
     def setup(self):


### PR DESCRIPTION
This PR enables multiple usage of the `--init-conds` flag, so that a user can select multiple initial trajectories to be used as the potential sources of initial conditions.