### PR TITLE
New command: `md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ miscellaneous operations on OPS output files.
 **Simulation Commands:**
 
 * `visit-all`:     Run MD to generate initial trajectories
+* `md`:            Run MD for fixed time or until a given ensemble is satisfied
 * `equilibrate`:   Run equilibration for path sampling
 * `pathsampling`:  Run any path sampling simulation, including TIS variants
 

--- a/paths_cli/commands/md.py
+++ b/paths_cli/commands/md.py
@@ -1,8 +1,6 @@
-import functools
-import operator
-
 import click
 
+import paths_cli.utils
 from paths_cli.parameters import (INPUT_FILE, OUTPUT_FILE, ENGINE,
                                   MULTI_ENSEMBLE, INIT_SNAP)
 
@@ -39,7 +37,6 @@ class EnsembleSatisfiedContinueConditions(object):
         self.satisfied = {ens: False for ens in ensembles}
 
     def _check_previous_frame(self, trajectory, start, unsatisfied):
-        # TODO: add some debug logging in here
         if -start > len(trajectory):
             # we've done the whole traj; don't keep going
             return False
@@ -91,10 +88,8 @@ def md_main(output_storage, engine, ensembles, nsteps, initial_frame):
         continue_cond = paths.LengthEnsemble(nsteps).can_append
 
     trajectory = engine.generate(initial_frame, running=continue_cond)
-    if output_storage is not None:
-        output_storage.save(trajectory)
-        output_storage.tags['final_conditions'] = trajectory
-
+    paths_cli.utils.tag_final_result(trajectory, output_storage,
+                                     'final_conditions')
     return trajectory, None
 
 CLI = md

--- a/paths_cli/commands/md.py
+++ b/paths_cli/commands/md.py
@@ -6,6 +6,9 @@ import click
 from paths_cli.parameters import (INPUT_FILE, OUTPUT_FILE, ENGINE,
                                   MULTI_ENSEMBLE, INIT_SNAP)
 
+import logging
+logger = logging.getLogger(__name__)
+
 @click.command(
     "md",
     short_help=("Run MD for fixed time or until a given ensemble is "
@@ -31,18 +34,63 @@ def md(input_file, output_file, engine, ensemble, nsteps, init_frame):
     )
 
 
+class EnsembleSatisfiedContinueConditions(object):
+    def __init__(self, ensembles):
+        self.satisfied = {ens: False for ens in ensembles}
+
+    def _check_previous_frame(self, trajectory, start, unsatisfied):
+        # TODO: add some debug logging in here
+        if -start > len(trajectory):
+            # we've done the whole traj; don't keep going
+            return False
+        subtraj = trajectory[start:]
+        logger.debug(str(subtraj) + "/" + str(trajectory))
+        for ens in unsatisfied:
+            if not ens.strict_can_prepend(subtraj, trusted=True):
+                # test if we can't prepend because we satsify
+                self.satisfied[ens] = ens(subtraj) or ens(subtraj[1:])
+                unsatisfied.remove(ens)
+        return bool(unsatisfied)
+
+    def _call_untrusted(self, trajectory):
+        self.satisfied = {ens: False for ens in self.satisfied}
+        for i in range(1, len(trajectory)):
+            keep_going = self(trajectory[:i], trusted=True)
+            if not keep_going:
+                return False
+        return self(trajectory, trusted=True)
+
+    def __call__(self, trajectory, trusted=False):
+        if not trusted:
+            return self._call_untrusted(trajectory)
+
+        # below here, trusted is True
+        unsatisfied = [ens for ens, done in self.satisfied.items()
+                       if not done]
+        # TODO: update on how many ensembles left, what frame number we are
+
+        if not unsatisfied:
+            return False
+
+        start = -1
+        while self._check_previous_frame(trajectory, start, unsatisfied):
+            start -= 1
+
+        return not all(self.satisfied.values())
+
+
 def md_main(output_storage, engine, ensembles, nsteps, initial_frame):
     import openpathsampling as paths
     if nsteps is not None and ensembles:
         raise RuntimeError("Options --ensemble and --nsteps cannot both be"
                            " used at once.")
 
-    if nsteps is not None:
-        ens = paths.LengthEnsemble(nsteps)
+    if ensembles:
+        continue_cond = EnsembleSatisfiedContinueConditions(ensembles)
     else:
-        ens = functools.reduce(operator.and_, ensembles)
+        continue_cond = paths.LengthEnsemble(nsteps).can_append
 
-    trajectory = engine.generate(initial_frame, running=ens.can_append)
+    trajectory = engine.generate(initial_frame, running=continue_cond)
     if output_storage is not None:
         output_storage.save(trajectory)
         output_storage.tags['final_conditions'] = trajectory

--- a/paths_cli/commands/md.py
+++ b/paths_cli/commands/md.py
@@ -66,9 +66,6 @@ class EnsembleSatisfiedContinueConditions(object):
                        if not done]
         # TODO: update on how many ensembles left, what frame number we are
 
-        if not unsatisfied:
-            return False
-
         start = -1
         while self._check_previous_frame(trajectory, start, unsatisfied):
             start -= 1

--- a/paths_cli/commands/md.py
+++ b/paths_cli/commands/md.py
@@ -21,6 +21,13 @@ logger = logging.getLogger(__name__)
 @INIT_SNAP.clicked(required=False)
 def md(input_file, output_file, engine, ensemble, nsteps, init_frame):
     """Run MD for for time of steps or until ensembles are satisfied.
+
+    This can either take a --nsteps or --ensemble, but not both. If the
+    --ensemble option is specfied more than once, then this will attempt to
+    run until all ensembles are satisfied by a subtrajectory.
+
+    This still respects the maximum number of frames as set in the engine,
+    and will terminate if the trajectory gets longer than that.
     """
     storage = INPUT_FILE.get(input_file)
     md_main(
@@ -33,6 +40,18 @@ def md(input_file, output_file, engine, ensemble, nsteps, init_frame):
 
 
 class EnsembleSatisfiedContinueConditions(object):
+    """Continuation condition for including subtrajs for each ensemble.
+
+    This object creates a continuation condition (a callable) analogous with
+    the ensemble ``can_append`` method. This will tell the trajectory to
+    keep running until, for each of the given ensembles, a subtrajectory has
+    been found that will satisfy the ensemble.
+
+    Parameters
+    ----------
+    ensembles: List[:class:`openpathsampling.Ensemble`]
+        the ensembles to satisfy
+    """
     def __init__(self, ensembles):
         self.satisfied = {ens: False for ens in ensembles}
 

--- a/paths_cli/commands/md.py
+++ b/paths_cli/commands/md.py
@@ -1,0 +1,55 @@
+import functools
+import operator
+
+import click
+
+from paths_cli.parameters import (INPUT_FILE, OUTPUT_FILE, ENGINE,
+                                  MULTI_ENSEMBLE, INIT_SNAP)
+
+@click.command(
+    "md",
+    short_help=("Run MD for fixed time or until a given ensemble is "
+                "satisfied"),
+)
+@INPUT_FILE.clicked(required=True)
+@OUTPUT_FILE.clicked(required=True)
+@ENGINE.clicked(required=False)
+@MULTI_ENSEMBLE.clicked(required=False)
+@click.option('-n', '--nsteps', type=int,
+              help="number of MD steps to run")
+@INIT_SNAP.clicked(required=False)
+def md(input_file, output_file, engine, ensemble, nsteps, init_frame):
+    """Run MD for for time of steps or until ensembles are satisfied.
+    """
+    storage = INPUT_FILE.get(input_file)
+    md_main(
+        output_storage=OUTPUT_FILE.get(output_file),
+        engine=ENGINE.get(storage, engine),
+        ensembles=MULTI_ENSEMBLE.get(storage, ensemble),
+        nsteps=nsteps,
+        initial_frame=INIT_SNAP.get(storage, init_frame)
+    )
+
+
+def md_main(output_storage, engine, ensembles, nsteps, initial_frame):
+    import openpathsampling as paths
+    if nsteps is not None and ensembles:
+        raise RuntimeError("Options --ensemble and --nsteps cannot both be"
+                           " used at once.")
+
+    if nsteps is not None:
+        ens = paths.LengthEnsemble(nsteps)
+    else:
+        ens = functools.reduce(operator.and_, ensembles)
+
+    trajectory = engine.generate(initial_frame, running=ens.can_append)
+    if output_storage is not None:
+        output_storage.save(trajectory)
+        output_storage.tags['final_conditions'] = trajectory
+
+    return trajectory, None
+
+CLI = md
+SECTION = "Simulation"
+REQUIRES_OPS = (1, 0)
+

--- a/paths_cli/commands/visit_all.py
+++ b/paths_cli/commands/visit_all.py
@@ -1,5 +1,6 @@
 import click
 
+import paths_cli.utils
 from paths_cli.parameters import (INPUT_FILE, OUTPUT_FILE, ENGINE, STATES,
                                   INIT_SNAP)
 
@@ -34,9 +35,8 @@ def visit_all_main(output_storage, states, engine, initial_frame):
     timestep = getattr(engine, 'timestep', None)
     visit_all_ens = paths.VisitAllStatesEnsemble(states, timestep=timestep)
     trajectory = engine.generate(initial_frame, [visit_all_ens.can_append])
-    if output_storage is not None:
-        output_storage.save(trajectory)
-        output_storage.tags['final_conditions'] = trajectory
+    paths_cli.utils.tag_final_result(trajectory, output_storage,
+                                     'final_conditions')
 
     return trajectory, None  # no simulation object to return here
 

--- a/paths_cli/parameters.py
+++ b/paths_cli/parameters.py
@@ -57,6 +57,11 @@ MULTI_ENGINE = OPSStorageLoadNames(
     store='engines'
 )
 
+MULTI_ENSEMBLE = OPSStorageLoadNames(
+    param=Option('--ensemble', type=str, multiple=True,
+                 help='name of index of ensemble' + HELP_MULTIPLE),
+    store='ensembles'
+)
 
 STATES = OPSStorageLoadNames(
     param=Option('-s', '--state', type=str, multiple=True,

--- a/paths_cli/tests/commands/test_md.py
+++ b/paths_cli/tests/commands/test_md.py
@@ -11,6 +11,32 @@ import openpathsampling as paths
 from openpathsampling.tests.test_helpers import \
         make_1d_traj, CalvinistDynamics
 
+class TestProgressReporter(object):
+    def setup(self):
+        self.progress = ProgressReporter(timestep=None, update_freq=5)
+
+    @pytest.mark.parametrize('timestep', [None, 0.1])
+    def test_progress_string(self, timestep):
+        progress = ProgressReporter(timestep, update_freq=5)
+        expected = "Ran 25 frames"
+        if timestep is not None:
+            expected += " [2.5]"
+        expected += '.\n'
+        assert progress.progress_string(25) == expected
+
+    @pytest.mark.parametrize('n_steps', [0, 5, 6])
+    @pytest.mark.parametrize('force', [True, False])
+    @patch('openpathsampling.tools.refresh_output',
+           lambda s: print(s, end=''))
+    def test_report_progress(self, n_steps, force, capsys):
+        self.progress.report_progress(n_steps, force)
+        expected = "Ran {n_steps} frames.\n".format(n_steps=n_steps)
+        out, err = capsys.readouterr()
+        if (n_steps in [0, 5]) or force:
+            assert out == expected
+        else:
+            assert out == ""
+
 class TestEnsembleSatisfiedContinueConditions(object):
     def setup(self):
         cv = paths.CoordinateFunctionCV('x', lambda x: x.xyz[0][0])

--- a/paths_cli/utils.py
+++ b/paths_cli/utils.py
@@ -1,0 +1,4 @@
+def tag_final_result(result, storage, tag='final_conditions'):
+    if storage:
+        storage.save(result)
+        storage.tags[tag] = result

--- a/paths_cli/utils.py
+++ b/paths_cli/utils.py
@@ -11,5 +11,6 @@ def tag_final_result(result, storage, tag='final_conditions'):
         the name to tag it with; default is 'final_conditions'
     """
     if storage:
+        print("Saving results to output file....")
         storage.save(result)
         storage.tags[tag] = result

--- a/paths_cli/utils.py
+++ b/paths_cli/utils.py
@@ -1,4 +1,15 @@
 def tag_final_result(result, storage, tag='final_conditions'):
+    """Save results to a tag in storage.
+
+    Parameters
+    ----------
+    result : UUIDObject
+        the result to store
+    storage : OPS storage
+        the output storage
+    tag : str
+        the name to tag it with; default is 'final_conditions'
+    """
     if storage:
         storage.save(result)
         storage.tags[tag] = result


### PR DESCRIPTION
This adds a new `md` subcommand, which allows a user to run normal MD using the given engine. This can be used with either the `--nsteps` parameter to run a specific number of steps, or (perhaps more interestingly) with the `--ensemble` parameter to create a trajectory that contains a subtrajectory satisfying the ensemble.

The `--ensemble` option can be given more than once. The resulting trajectory will have subtrajectories that satisfy each of the provided ensembles.