### PR TITLE
Simulation Setup Wizard

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,3 +7,4 @@ exclude_lines =
     no-cov
     def __repr__
     raise NotImplementedError
+    __name__ == "__main__":

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -61,6 +61,6 @@ jobs:
           PY_COLORS: "1"
         run: |
           python -c "import paths_cli"
-          py.test -vv --cov --cov-report xml:cov.xml --ignore paths_cli/tests/wizard
+          py.test -vv --cov --cov-report xml:cov.xml
       - name: "Report coverage"
         run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -57,8 +57,10 @@ jobs:
           fi
           python autorelease_check.py --branch $BRANCH --even ${EVENT}
       - name: "Unit tests"
+        env:
+          PY_COLORS: "1"
         run: |
           python -c "import paths_cli"
-          py.test -vv --cov --cov-report xml:cov.xml
+          py.test -vv --cov --cov-report xml:cov.xml --ignore paths_cli/tests/wizard
       - name: "Report coverage"
         run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -31,7 +31,7 @@ jobs:
         INTEGRATIONS: [""]
         include:
           - CONDA_PY: 3.9
-            INTEGRATIONS: ['all-optionals']
+            INTEGRATIONS: 'all-optionals'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -30,8 +30,8 @@ jobs:
           - 3.6
         INTEGRATIONS: [""]
         include:
-          CONDA_PY: 3.9
-          INTEGRATIONS: ['all-optionals']
+          - CONDA_PY: 3.9
+            INTEGRATIONS: ['all-optionals']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -43,7 +43,7 @@ jobs:
       - name: "Install testing tools"
         run: python -m pip install -r ./devtools/tests_require.txt
       - name: "Install integrations"
-        if: matrinx.INTEGRATIONS == 'all-optionals'
+        if: matrix.INTEGRATIONS == 'all-optionals'
         run: conda install -c conda-forge -y openmm openmmtools mdtraj
       - name: "Install"
         run: |

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -28,10 +28,10 @@ jobs:
           - 3.8
           - 3.7
           - 3.6
-      INTEGRATIONS: [""]
-      include:
-        CONDA_PY: 3.9
-        INTEGRATIONS: ['all-optionals']
+        INTEGRATIONS: [""]
+        include:
+          CONDA_PY: 3.9
+          INTEGRATIONS: ['all-optionals']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -28,6 +28,10 @@ jobs:
           - 3.8
           - 3.7
           - 3.6
+      INTEGRATIONS: [""]
+      include:
+        CONDA_PY: 3.9
+        INTEGRATIONS: ['all-optionals']
 
     steps:
       - uses: actions/checkout@v2
@@ -38,6 +42,9 @@ jobs:
           python-version: ${{ matrix.CONDA_PY }}
       - name: "Install testing tools"
         run: python -m pip install -r ./devtools/tests_require.txt
+      - name: "Install integrations"
+        if: matrinx.INTEGRATIONS == 'all-optionals'
+        run: conda install -c conda-forge -y openmm openmmtools mdtraj
       - name: "Install"
         run: |
           conda install pip

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          fetch-depth: 2
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -35,9 +35,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
         with:
           fetch-depth: 2
+      - uses: actions/setup-python@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,6 +60,7 @@ wrappers around well-tested OPS code.
    plugins
    parameters
    workflows
+   wizard
    full_cli
    api/index
 

--- a/docs/wizard.rst
+++ b/docs/wizard.rst
@@ -1,0 +1,8 @@
+.. _wizard:
+
+Writing tools for the Wizard
+============================
+
+The Wizard API is still rapidly in flux, and we don't recommend developing
+custom Wizard tools at this time. However, once its API is more stable, the
+Wizard will be extendable by outside developers.

--- a/paths_cli/commands/wizard.py
+++ b/paths_cli/commands/wizard.py
@@ -5,7 +5,7 @@ from paths_cli.wizard.two_state_tps import TWO_STATE_TPS_WIZARD
     'wizard',
     short_help="run wizard for setting up simulations",
 )
-def wizard():
+def wizard():  # no-cov
     TWO_STATE_TPS_WIZARD.run_wizard()
 
 CLI = wizard

--- a/paths_cli/commands/wizard.py
+++ b/paths_cli/commands/wizard.py
@@ -1,0 +1,12 @@
+import click
+from paths_cli.wizard.two_state_tps import TWO_STATE_TPS_WIZARD
+
+@click.command(
+    'wizard',
+    short_help="run wizard for setting up simulations",
+)
+def wizard():
+    TWO_STATE_TPS_WIZARD.run_wizard()
+
+CLI = wizard
+SECTION = "Simulation setup"

--- a/paths_cli/parsing/tools.py
+++ b/paths_cli/parsing/tools.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 def custom_eval(obj, named_objs=None):
     string = str(obj)
     # TODO: check that the only attribute access comes from a whitelist
@@ -11,10 +13,24 @@ def custom_eval(obj, named_objs=None):
 class UnknownAtomsError(RuntimeError):
     pass
 
-def mdtraj_parse_atomlist(inp_str, topology):
+def mdtraj_parse_atomlist(inp_str, n_atoms, topology=None):
+    """
+    n_atoms: int
+        number of atoms expected
+    """
+    # TODO: change n_atoms to the shape desired?
     # TODO: enable the parsing of either string-like atom labels or numeric
-    try:
-        arr = custom_eval(inp_str)
-    except:
-        pass  # on any error, we do it the hard way
-    pass
+    indices = custom_eval(inp_str)
+
+    arr = np.array(indices)
+    if arr.dtype != int:
+        raise TypeError("Input is not integers")
+    if arr.shape != (1, n_atoms):
+        # try to clean it up
+        if len(arr.shape) == 1 and arr.shape[0] ==  n_atoms:
+            arr.shape = (1, n_atoms)
+        else:
+            raise TypeError(f"Invalid input. Requires {n_atoms} "
+                            "atoms.")
+
+    return arr

--- a/paths_cli/parsing/tools.py
+++ b/paths_cli/parsing/tools.py
@@ -1,0 +1,20 @@
+def custom_eval(obj, named_objs=None):
+    string = str(obj)
+    # TODO: check that the only attribute access comes from a whitelist
+    namespace = {
+        'np': __import__('numpy'),
+        'math': __import__('math'),
+    }
+    return eval(string, namespace)
+
+
+class UnknownAtomsError(RuntimeError):
+    pass
+
+def mdtraj_parse_atomlist(inp_str, topology):
+    # TODO: enable the parsing of either string-like atom labels or numeric
+    try:
+        arr = custom_eval(inp_str)
+    except:
+        pass  # on any error, we do it the hard way
+    pass

--- a/paths_cli/parsing/tools.py
+++ b/paths_cli/parsing/tools.py
@@ -1,8 +1,17 @@
 import numpy as np
 
 def custom_eval(obj, named_objs=None):
+    """Parse user input to allow simple math.
+
+    This allows certain user input to be treated as a simplified subset of
+    Python. In particular, this is intended to allow simple arithmetic. It
+    allows use of the modules numpy (as ``np``) and math, which provide
+    potentially useful functions (e.g., ``cos``) as well as constants (e.g.,
+    ``pi``).
+    """
     string = str(obj)
     # TODO: check that the only attribute access comes from a whitelist
+    # (parse the AST for that)
     namespace = {
         'np': __import__('numpy'),
         'math': __import__('math'),

--- a/paths_cli/tests/parsing/test_tools.py
+++ b/paths_cli/tests/parsing/test_tools.py
@@ -1,10 +1,14 @@
 import pytest
 import numpy.testing as npt
+import numpy as np
+import math
 
 from paths_cli.parsing.tools import *
 
 @pytest.mark.parametrize('expr,expected', [
-    ('1+1', 2)
+    ('1+1', 2),
+    ('np.pi / 2', np.pi / 2),
+    ('math.cos(1.5)', math.cos(1.5)),
 ])
 def test_custom_eval(expr, expected):
     npt.assert_allclose(custom_eval(expr), expected)

--- a/paths_cli/tests/parsing/test_tools.py
+++ b/paths_cli/tests/parsing/test_tools.py
@@ -1,0 +1,14 @@
+import pytest
+import numpy.testing as npt
+
+from paths_cli.parsing.tools import *
+
+@pytest.mark.parametrize('expr,expected', [
+    ('1+1', 2)
+])
+def test_custom_eval(expr, expected):
+    npt.assert_allclose(custom_eval(expr), expected)
+
+def test_mdtraj_parse_atomlist_bad_input():
+    with pytest.raises(TypeError, match="not integers"):
+        mdtraj_parse_atomlist("['a', 'b']", n_atoms=2)

--- a/paths_cli/tests/test_parameters.py
+++ b/paths_cli/tests/test_parameters.py
@@ -38,8 +38,8 @@ def undo_monkey_patch(stored_functions):
     import importlib
     importlib.reload(paths.netcdfplus)
     importlib.reload(paths.collectivevariable)
+    importlib.reload(paths.collectivevariables)
     importlib.reload(paths)
-
 
 
 class ParameterTest(object):

--- a/paths_cli/tests/utils.py
+++ b/paths_cli/tests/utils.py
@@ -1,0 +1,18 @@
+import urllib.request
+
+try:
+    urllib.request.urlopen('https://www.google.com')
+except:
+    HAS_INTERNET = False
+else:
+    HAS_INTERNET = True
+
+def assert_url(url):
+    if not HAS_INTERNET:
+        pytest.skip("Internet connection seems faulty")
+
+    # TODO: On a 404 this will raise a urllib.error.HTTPError. It would be
+    # nice to give some better output to the user here.
+    resp = urllib.request.urlopen(url)
+    assert resp.status == 200
+

--- a/paths_cli/tests/wizard/conftest.py
+++ b/paths_cli/tests/wizard/conftest.py
@@ -47,4 +47,24 @@ def ad_engine(ad_openmm):
         ).named('ad_engine')
     return engine
 
-# TODO: add fixtures for all the AD things: CVs, states
+@pytest.fixture
+def toy_engine():
+    pes = (paths.engines.toy.OuterWalls([1.0, 1.0], [1.0, 1.0])
+           + paths.engines.toy.Gaussian(-1.0, [12.0, 12.0], [-0.5, 0.0])
+           + paths.engines.toy.Gaussian(-1.0, [12.0, 12.0], [0.5, 0.0]))
+    topology = paths.engines.toy.Topology(n_spatial=2,
+                                          masses=[1.0],
+                                          pes=pes)
+    integ = paths.engines.toy.LangevinBAOABIntegrator(
+        dt=0.02,
+        temperature=0.1,
+        gamma=2.5
+    )
+    options = {'integ': integ,
+               'n_frames_max': 5000,
+               'n_steps_per_frame': 1}
+    engine = paths.engines.toy.Engine(
+        options=options,
+        topology=topology
+    ).named('toy-engine')
+    return engine

--- a/paths_cli/tests/wizard/conftest.py
+++ b/paths_cli/tests/wizard/conftest.py
@@ -1,0 +1,50 @@
+import pytest
+
+import openpathsampling as paths
+import mdtraj as md
+
+@pytest.fixture
+def ad_openmm(tmpdir):
+    """
+    Provide directory with files to start alanine depeptide sim in OpenMM
+    """
+    mm = pytest.importorskip('simtk.openmm')
+    u = pytest.importorskip('simtk.unit')
+    openmmtools = pytest.importorskip('openmmtools')
+    md = pytest.importorskip('mdtraj')
+    testsystem = openmmtools.testsystems.AlanineDipeptideVacuum()
+    integrator = openmmtools.integrators.VVVRIntegrator(
+        300 * u.kelvin,
+        1.0 / u.picosecond,
+        2.0 * u.femtosecond
+    )
+    traj = md.Trajectory([testsystem.positions.value_in_unit(u.nanometer)],
+                         topology=testsystem.mdtraj_topology)
+    files = {'integrator.xml': integrator,
+             'system.xml': testsystem.system}
+    with tmpdir.as_cwd():
+        for fname, obj in files.items():
+            with open(fname, mode='w') as f:
+                f.write(mm.XmlSerializer.serialize(obj))
+
+        traj.save('ad.pdb')
+
+    return tmpdir
+
+@pytest.fixture
+def ad_engine(ad_openmm):
+    with ad_openmm.as_cwd():
+        pdb = md.load('ad.pdb')
+        topology = paths.engines.openmm.topology.MDTrajTopology(
+            pdb.topology
+        )
+        engine = paths.engines.openmm.Engine(
+            system='system.xml',
+            integrator='integrator.xml',
+            topology=topology,
+            options={'n_steps_per_frame': 10,
+                     'n_frames_max': 10000}
+        ).named('ad_engine')
+    return engine
+
+# TODO: add fixtures for all the AD things: CVs, states

--- a/paths_cli/tests/wizard/conftest.py
+++ b/paths_cli/tests/wizard/conftest.py
@@ -35,7 +35,7 @@ def ad_openmm(tmpdir):
 def ad_engine(ad_openmm):
     with ad_openmm.as_cwd():
         pdb = md.load('ad.pdb')
-        topology = paths.engines.openmm.topology.MDTrajTopology(
+        topology = paths.engines.MDTrajTopology(
             pdb.topology
         )
         engine = paths.engines.openmm.Engine(

--- a/paths_cli/tests/wizard/conftest.py
+++ b/paths_cli/tests/wizard/conftest.py
@@ -68,3 +68,12 @@ def toy_engine():
         topology=topology
     ).named('toy-engine')
     return engine
+
+
+@pytest.fixture
+def tps_network():
+    cv = paths.CoordinateFunctionCV('x', lambda s: s.xyz[0][0])
+    state_A = paths.CVDefinedVolume(cv, float("-inf"), 0).named("A")
+    state_B = paths.CVDefinedVolume(cv, 0, float("inf")).named("B")
+    network = paths.TPSNetwork(state_A, state_B).named('tps-network')
+    return network

--- a/paths_cli/tests/wizard/mock_wizard.py
+++ b/paths_cli/tests/wizard/mock_wizard.py
@@ -1,5 +1,5 @@
 from paths_cli.wizard.wizard import Wizard
-import mock
+from unittest import mock
 
 def make_mock_wizard(inputs):
     wizard = Wizard([])

--- a/paths_cli/tests/wizard/mock_wizard.py
+++ b/paths_cli/tests/wizard/mock_wizard.py
@@ -1,0 +1,12 @@
+from paths_cli.wizard.wizard import Wizard
+import mock
+
+def make_mock_wizard(inputs):
+    wizard = Wizard([])
+    wizard.console.input = mock.Mock(return_value=inputs)
+    return wizard
+
+def make_mock_retry_wizard(inputs):
+    wizard = Wizard([])
+    wizard.console.input = mock.Mock(side_effect=inputs)
+    return wizard

--- a/paths_cli/tests/wizard/mock_wizard.py
+++ b/paths_cli/tests/wizard/mock_wizard.py
@@ -28,7 +28,12 @@ class MockConsole:
 
     def input(self, content):
         self.input_call_count += 1
-        user_input = next(self._input_iter)
+        try:
+            user_input = next(self._input_iter)
+        except StopIteration as e:
+            print(self.log_text)
+            raise e
+
         self.log.append(content + " " + user_input)
         return user_input
 

--- a/paths_cli/tests/wizard/mock_wizard.py
+++ b/paths_cli/tests/wizard/mock_wizard.py
@@ -10,3 +10,36 @@ def make_mock_retry_wizard(inputs):
     wizard = Wizard([])
     wizard.console.input = mock.Mock(side_effect=inputs)
     return wizard
+
+class MockConsole:
+    def __init__(self, inputs=None):
+        if isinstance(inputs, str):
+            inputs = [inputs]
+        elif inputs is None:
+            inputs = []
+        self.inputs = inputs
+        self._input_iter = iter(inputs)
+        self.log = []
+        self.width = 80
+        self.input_call_count = 0
+
+    def print(self, content=""):
+        self.log.append(content)
+
+    def input(self, content):
+        self.input_call_count += 1
+        user_input = next(self._input_iter)
+        self.log.append(content + " " + user_input)
+        return user_input
+
+    @property
+    def log_text(self):
+        return "\n".join(self.log)
+
+def mock_wizard(inputs):
+    wizard = Wizard([])
+    console = MockConsole(inputs)
+    wizard.console = console
+    return wizard
+
+

--- a/paths_cli/tests/wizard/test_core.py
+++ b/paths_cli/tests/wizard/test_core.py
@@ -48,4 +48,3 @@ def test_get_missing_object(length, expected):
     result = get_missing_object(wizard, dct, display_name='string',
                                 fallback_func=fallback)
     assert result == expected
-    pass

--- a/paths_cli/tests/wizard/test_core.py
+++ b/paths_cli/tests/wizard/test_core.py
@@ -1,0 +1,51 @@
+import pytest
+import mock
+
+from openpathsampling.experimental.storage.collective_variables import \
+        CoordinateFunctionCV
+
+from paths_cli.wizard.core import *
+
+from paths_cli.tests.wizard.mock_wizard import (
+    make_mock_wizard, make_mock_retry_wizard
+)
+
+def test_name():
+    wizard = make_mock_wizard('foo')
+    cv = CoordinateFunctionCV(lambda s: s.xyz[0][0])
+    assert not cv.is_named
+    result = name(wizard, cv, obj_type="CV", store_name="cvs")
+    assert result is cv
+    assert result.is_named
+    assert result.name == 'foo'
+
+def test_name_exists():
+    wizard = make_mock_retry_wizard(['foo', 'bar'])
+    wizard.cvs['foo'] = 'placeholder'
+    cv = CoordinateFunctionCV(lambda s: s.xyz[0][0])
+    assert not cv.is_named
+    result = name(wizard, cv, obj_type="CV", store_name="cvs")
+    assert result is cv
+    assert result.is_named
+    assert result.name == 'bar'
+    assert wizard.console.input.call_count == 2
+
+@pytest.mark.parametrize('req,expected', [
+    (('foo', 2, 2), '2'), (('foo', 2, float('inf')), 'at least 2'),
+    (('foo', 0, 2), 'at most 2'),
+    (('foo', 1, 3), 'at least 1 and at most 3')
+])
+def test_interpret_req(req, expected):
+    assert interpret_req(req) == expected
+
+@pytest.mark.parametrize('length,expected', [
+    (0, 'foo'), (1, 'baz'), (2, 'quux'),
+])
+def test_get_missing_object(length, expected):
+    dct = dict([('bar', 'baz'), ('qux', 'quux')][:length])
+    fallback = lambda x: 'foo'
+    wizard = make_mock_wizard('2')
+    result = get_missing_object(wizard, dct, display_name='string',
+                                fallback_func=fallback)
+    assert result == expected
+    pass

--- a/paths_cli/tests/wizard/test_core.py
+++ b/paths_cli/tests/wizard/test_core.py
@@ -10,26 +10,6 @@ from paths_cli.tests.wizard.mock_wizard import (
     make_mock_wizard, make_mock_retry_wizard
 )
 
-# def test_name():
-    # wizard = make_mock_wizard('foo')
-    # cv = CoordinateFunctionCV(lambda s: s.xyz[0][0])
-    # assert not cv.is_named
-    # result = name(wizard, cv, obj_type="CV", store_name="cvs")
-    # assert result is cv
-    # assert result.is_named
-    # assert result.name == 'foo'
-
-# def test_name_exists():
-    # wizard = make_mock_retry_wizard(['foo', 'bar'])
-    # wizard.cvs['foo'] = 'placeholder'
-    # cv = CoordinateFunctionCV(lambda s: s.xyz[0][0])
-    # assert not cv.is_named
-    # result = name(wizard, cv, obj_type="CV", store_name="cvs")
-    # assert result is cv
-    # assert result.is_named
-    # assert result.name == 'bar'
-    # assert wizard.console.input.call_count == 2
-
 @pytest.mark.parametrize('req,expected', [
     (('foo', 2, 2), '2'), (('foo', 2, float('inf')), 'at least 2'),
     (('foo', 0, 2), 'at most 2'),

--- a/paths_cli/tests/wizard/test_core.py
+++ b/paths_cli/tests/wizard/test_core.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from openpathsampling.experimental.storage.collective_variables import \
         CoordinateFunctionCV

--- a/paths_cli/tests/wizard/test_core.py
+++ b/paths_cli/tests/wizard/test_core.py
@@ -10,25 +10,25 @@ from paths_cli.tests.wizard.mock_wizard import (
     make_mock_wizard, make_mock_retry_wizard
 )
 
-def test_name():
-    wizard = make_mock_wizard('foo')
-    cv = CoordinateFunctionCV(lambda s: s.xyz[0][0])
-    assert not cv.is_named
-    result = name(wizard, cv, obj_type="CV", store_name="cvs")
-    assert result is cv
-    assert result.is_named
-    assert result.name == 'foo'
+# def test_name():
+    # wizard = make_mock_wizard('foo')
+    # cv = CoordinateFunctionCV(lambda s: s.xyz[0][0])
+    # assert not cv.is_named
+    # result = name(wizard, cv, obj_type="CV", store_name="cvs")
+    # assert result is cv
+    # assert result.is_named
+    # assert result.name == 'foo'
 
-def test_name_exists():
-    wizard = make_mock_retry_wizard(['foo', 'bar'])
-    wizard.cvs['foo'] = 'placeholder'
-    cv = CoordinateFunctionCV(lambda s: s.xyz[0][0])
-    assert not cv.is_named
-    result = name(wizard, cv, obj_type="CV", store_name="cvs")
-    assert result is cv
-    assert result.is_named
-    assert result.name == 'bar'
-    assert wizard.console.input.call_count == 2
+# def test_name_exists():
+    # wizard = make_mock_retry_wizard(['foo', 'bar'])
+    # wizard.cvs['foo'] = 'placeholder'
+    # cv = CoordinateFunctionCV(lambda s: s.xyz[0][0])
+    # assert not cv.is_named
+    # result = name(wizard, cv, obj_type="CV", store_name="cvs")
+    # assert result is cv
+    # assert result.is_named
+    # assert result.name == 'bar'
+    # assert wizard.console.input.call_count == 2
 
 @pytest.mark.parametrize('req,expected', [
     (('foo', 2, 2), '2'), (('foo', 2, float('inf')), 'at least 2'),

--- a/paths_cli/tests/wizard/test_cvs.py
+++ b/paths_cli/tests/wizard/test_cvs.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 import numpy as np
 
 from functools import partial

--- a/paths_cli/tests/wizard/test_cvs.py
+++ b/paths_cli/tests/wizard/test_cvs.py
@@ -1,0 +1,95 @@
+import pytest
+import mock
+import numpy as np
+
+from functools import partial
+
+from paths_cli.tests.wizard.mock_wizard import mock_wizard
+
+from paths_cli.wizard.cvs import (
+    _get_topology, _get_atom_indices, distance, angle, dihedral, rmsd,
+    coordinate, cvs, SUPPORTED_CVS
+)
+
+import openpathsampling as paths
+from openpathsampling.experimental.storage.collective_variables import \
+        MDTrajFunctionCV
+from openpathsampling.tests.test_helpers import make_1d_traj
+
+@pytest.mark.parametrize('n_engines', [0, 1, 2])
+def test_get_topology(ad_engine, n_engines):
+    inputs = {0: [], 1: [], 2: ['1']}[n_engines]
+    wizard = mock_wizard(inputs)
+    engines = [ad_engine, paths.engines.NoEngine(None).named('foo')]
+    wizard.engines = {eng.name: eng for eng in engines[:n_engines]}
+    def mock_register(obj, obj_type, store_name):
+        wizard.engines[obj.name] = obj
+    wizard.register = mock_register
+
+    mock_engines = mock.Mock(return_value=ad_engine)
+    patch_loc = 'paths_cli.wizard.engines.engines'
+    with mock.patch(patch_loc, new=mock_engines):
+        topology = _get_topology(wizard)
+    assert isinstance(topology,
+                      paths.engines.openmm.topology.MDTrajTopology)
+
+@pytest.mark.parametrize('inputs', [
+    (['[[1, 2]]']), (['1, 2']),
+    (['[[1, 2, 3]]', '[[1, 2]]']),
+])
+def test_get_atom_indices(ad_engine, inputs):
+    wizard = mock_wizard(inputs)
+    arr = _get_atom_indices(wizard, ad_engine.topology, 2, "use")
+    np.testing.assert_array_equal(arr, np.array([[1, 2]]))
+    assert wizard.console.input_call_count == len(inputs)
+    if len(inputs) > 1:
+        assert "I didn't understand" in wizard.console.log_text
+
+def _mdtraj_function_test(wizard, func, md_func, ad_openmm, ad_engine):
+    md = pytest.importorskip('mdtraj')
+    wizard.engines[ad_engine.name] = ad_engine
+    with ad_openmm.as_cwd():
+        cv = func(wizard)
+        pdb = md.load('ad.pdb')
+    assert isinstance(cv, MDTrajFunctionCV)
+    traj = paths.engines.openmm.trajectory_from_mdtraj(pdb)
+    np.testing.assert_array_almost_equal(md_func(pdb)[0], cv(traj))
+
+def test_distance(ad_openmm, ad_engine):
+    md = pytest.importorskip('mdtraj')
+    wizard = mock_wizard(['0, 1'])
+    md_func = partial(md.compute_distances, atom_pairs=[[0, 1]])
+    _mdtraj_function_test(wizard, distance, md_func, ad_openmm, ad_engine)
+
+def test_angle(ad_openmm, ad_engine):
+    md = pytest.importorskip('mdtraj')
+    wizard = mock_wizard(['0, 1, 2'])
+    md_func = partial(md.compute_angles, angle_indices=[[0, 1, 2]])
+    _mdtraj_function_test(wizard, angle, md_func, ad_openmm, ad_engine)
+
+def test_dihedral(ad_openmm, ad_engine):
+    md = pytest.importorskip('mdtraj')
+    wizard = mock_wizard(['0, 1, 2, 3'])
+    md_func = partial(md.compute_dihedrals, indices=[[0, 1, 2, 3]])
+    _mdtraj_function_test(wizard, dihedral, md_func, ad_openmm, ad_engine)
+
+@pytest.mark.parametrize('inputs', [
+    (['0', 'x']), ('foo', '0', 'x'), (['0', 'q', 'x'])
+])
+def test_coordinate(inputs):
+    wizard = mock_wizard(inputs)
+    cv = coordinate(wizard)
+    traj = make_1d_traj([5.0])
+    assert cv(traj[0]) == 5.0
+    if 'foo' in inputs:
+        assert "I can't make an atom index" in wizard.console.log_text
+    if 'q' in inputs:
+        assert "Please select one of" in wizard.console.log_text
+
+@pytest.mark.parametrize('inputs', [(['foo', 'Distance']), (['Distance'])])
+def test_cvs(inputs):
+    wizard = mock_wizard(inputs)
+    say_hello = mock.Mock(return_value="hello")
+    with mock.patch.dict(SUPPORTED_CVS, {'Distance': say_hello}):
+        assert cvs(wizard) == "hello"
+        assert wizard.console.input_call_count == len(inputs)

--- a/paths_cli/tests/wizard/test_cvs.py
+++ b/paths_cli/tests/wizard/test_cvs.py
@@ -30,8 +30,7 @@ def test_get_topology(ad_engine, n_engines):
     patch_loc = 'paths_cli.wizard.engines.engines'
     with mock.patch(patch_loc, new=mock_engines):
         topology = _get_topology(wizard)
-    assert isinstance(topology,
-                      paths.engines.openmm.topology.MDTrajTopology)
+    assert isinstance(topology, paths.engines.MDTrajTopology)
 
 @pytest.mark.parametrize('inputs', [
     (['[[1, 2]]']), (['1, 2']),

--- a/paths_cli/tests/wizard/test_engines.py
+++ b/paths_cli/tests/wizard/test_engines.py
@@ -1,0 +1,14 @@
+import pytest
+import mock
+
+from paths_cli.tests.wizard.mock_wizard import mock_wizard
+
+from paths_cli.wizard.engines import engines, SUPPORTED_ENGINES
+
+def test_engines():
+    wizard = mock_wizard(['foo'])
+    with mock.patch.dict(SUPPORTED_ENGINES,
+                         {'foo': mock.Mock(return_value='ran foo')}):
+        foo = engines(wizard)
+    assert foo == 'ran foo'
+

--- a/paths_cli/tests/wizard/test_engines.py
+++ b/paths_cli/tests/wizard/test_engines.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from paths_cli.tests.wizard.mock_wizard import mock_wizard
 

--- a/paths_cli/tests/wizard/test_errors.py
+++ b/paths_cli/tests/wizard/test_errors.py
@@ -1,0 +1,21 @@
+import pytest
+import mock
+
+from paths_cli.tests.wizard.mock_wizard import mock_wizard
+
+from paths_cli.wizard.errors import *
+
+def test_impossible_error_default():
+    with pytest.raises(ImpossibleError, match="You should never see this."):
+        raise ImpossibleError()
+
+@pytest.mark.parametrize('inputs', ['r', 'q'])
+def test_not_installed(inputs):
+    expected = {'r': RestartObjectException, 'q': SystemExit}[inputs]
+    wizard = mock_wizard([inputs])
+    with pytest.raises(expected):
+        not_installed(wizard, 'foo', 'widget')
+    log = wizard.console.log_text
+    assert 'foo installed' in log
+    assert 'different widget' in log
+

--- a/paths_cli/tests/wizard/test_errors.py
+++ b/paths_cli/tests/wizard/test_errors.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from paths_cli.tests.wizard.mock_wizard import mock_wizard
 

--- a/paths_cli/tests/wizard/test_load_from_ops.py
+++ b/paths_cli/tests/wizard/test_load_from_ops.py
@@ -94,5 +94,3 @@ def test_load_from_ops(ops_file_fixture):
 
     assert isinstance(obj, NamedObj)
     assert obj.name == 'bar'
-
-    pass

--- a/paths_cli/tests/wizard/test_load_from_ops.py
+++ b/paths_cli/tests/wizard/test_load_from_ops.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 import openpathsampling as paths
 

--- a/paths_cli/tests/wizard/test_load_from_ops.py
+++ b/paths_cli/tests/wizard/test_load_from_ops.py
@@ -1,0 +1,98 @@
+import pytest
+import mock
+
+import openpathsampling as paths
+
+from paths_cli.tests.wizard.mock_wizard import mock_wizard
+
+from paths_cli.wizard.load_from_ops import (
+    named_objs_helper, _get_ops_storage, _get_ops_object, load_from_ops
+)
+
+# for some reason I couldn't get these to work with MagicMock
+class NamedObj:
+    def __init__(self, name):
+        self.name = name
+        self.is_named = True
+
+class FakeStore:
+    def __init__(self, objects):
+        self._objects = objects
+        self._named_objects = {obj.name: obj for obj in objects}
+
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            return self._objects[key]
+        elif isinstance(key, str):
+            return self._named_objects[key]
+        else:
+            raise TypeError("Huh?")
+
+    def __iter__(self):
+        return iter(self._objects)
+
+class FakeStorage:
+    def __init__(self, foo):
+        self.foo = foo
+
+@pytest.fixture
+def ops_file_fixture():
+    # store name 'foo', objects named 'bar', 'baz'
+    bar = NamedObj('bar')
+    baz = NamedObj('baz')
+    foo = FakeStore([bar, baz])
+    storage = FakeStorage(foo)
+    return storage
+
+def test_named_objs_helper(ops_file_fixture):
+    wizard = mock_wizard([])
+    helper_func = named_objs_helper(ops_file_fixture, 'foo')
+    helper_func(wizard, 'any')
+    assert "what I found" in wizard.console.log_text
+    assert "bar" in wizard.console.log_text
+    assert "baz" in wizard.console.log_text
+
+@pytest.mark.parametrize('with_failure', [False, True])
+def test_get_ops_storage(tmpdir, with_failure):
+    fake_file = tmpdir / 'foo.db'
+    fake_file.write_text('bar', 'utf-8')
+
+    failure_text = ['baz.db'] if with_failure else []
+    wizard = mock_wizard(failure_text + [str(fake_file)])
+
+    with mock.patch('paths_cli.wizard.load_from_ops.INPUT_FILE',
+                    new=mock.Mock(get=open)):
+        storage = _get_ops_storage(wizard)
+    assert storage.read() == 'bar'
+    if with_failure:
+        assert 'something went wrong' in wizard.console.log_text
+    else:
+        assert 'something went wrong' not in wizard.console.log_text
+
+@pytest.mark.parametrize('with_failure', [False, True])
+def test_get_ops_object(ops_file_fixture, with_failure):
+    failure_text = ['qux'] if with_failure else []
+    wizard = mock_wizard(failure_text + ['bar'])
+    obj = _get_ops_object(wizard, ops_file_fixture,
+                          store_name='foo',
+                          obj_name='FOOMAGIC')
+    assert isinstance(obj, NamedObj)
+    assert obj.name == 'bar'
+    log = wizard.console.log_text
+    assert 'name of the FOOMAGIC' in log
+    fail_msg = 'Something went wrong'
+    if with_failure:
+        assert fail_msg in log
+    else:
+        assert fail_msg not in log
+
+def test_load_from_ops(ops_file_fixture):
+    wizard = mock_wizard(['anyfile.db', 'bar'])
+    with mock.patch('paths_cli.wizard.load_from_ops.INPUT_FILE.get',
+                    mock.Mock(return_value=ops_file_fixture)):
+        obj = load_from_ops(wizard, 'foo', 'FOOMAGIC')
+
+    assert isinstance(obj, NamedObj)
+    assert obj.name == 'bar'
+
+    pass

--- a/paths_cli/tests/wizard/test_openmm.py
+++ b/paths_cli/tests/wizard/test_openmm.py
@@ -1,0 +1,83 @@
+import pytest
+import mock
+
+from paths_cli.tests.wizard.mock_wizard import mock_wizard
+
+from paths_cli.wizard.openmm import (
+    _load_openmm_xml, _load_topology, openmm
+)
+
+@pytest.fixture
+def ad_openmm(tmpdir):
+    """
+    Provide directory with files to start alanine depeptide sim in OpenMM
+    """
+    mm = pytest.importorskip('simtk.openmm')
+    u = pytest.importorskip('simtk.unit')
+    openmmtools = pytest.importorskip('openmmtools')
+    md = pytest.importorskip('mdtraj')
+    testsystem = openmmtools.testsystems.AlanineDipeptideVacuum()
+    integrator = openmmtools.integrators.VVVRIntegrator(
+        300 * u.kelvin,
+        1.0 / u.picosecond,
+        2.0 * u.femtosecond
+    )
+    traj = md.Trajectory([testsystem.positions.value_in_unit(u.nanometer)],
+                         topology=testsystem.mdtraj_topology)
+    files = {'integrator.xml': integrator,
+             'system.xml': testsystem.system}
+    with tmpdir.as_cwd():
+        for fname, obj in files.items():
+            with open(fname, mode='w') as f:
+                f.write(mm.XmlSerializer.serialize(obj))
+
+        traj.save('ad.pdb')
+
+    return tmpdir
+
+
+@pytest.mark.parametrize('obj_type', ['system', 'integrator', 'foo'])
+def test_load_openmm_xml(ad_openmm, obj_type):
+    mm = pytest.importorskip('simtk.openmm')
+    filename = f"{obj_type}.xml"
+    inputs = [filename]
+    expected_count = 1
+    if obj_type == 'foo':
+        inputs.append('integrator.xml')
+        expected_count = 2
+
+    wizard = mock_wizard(inputs)
+    superclass = {'integrator': mm.CustomIntegrator,
+                  'system': mm.System,
+                  'foo': mm.CustomIntegrator}[obj_type]
+    with ad_openmm.as_cwd():
+        obj = _load_openmm_xml(wizard, obj_type)
+        assert isinstance(obj, superclass)
+
+    assert wizard.console.input_call_count == expected_count
+
+@pytest.mark.parametrize('setup', ['normal', 'bad_filetype', 'no_file'])
+def test_load_topology(ad_openmm, setup):
+    import openpathsampling as paths
+    inputs = {'normal': [],
+              'bad_filetype': ['foo.bar'],
+              'no_file': ['foo.pdb']}[setup]
+    expected_text = {'normal': "PDB file",
+                     'bad_filetype': 'trr',
+                     'no_file': 'No such file'}[setup]
+    inputs += ['ad.pdb']
+    wizard = mock_wizard(inputs)
+    with ad_openmm.as_cwd():
+        top = _load_topology(wizard)
+
+    assert isinstance(top, paths.engines.openmm.topology.MDTrajTopology)
+    assert wizard.console.input_call_count == len(inputs)
+    assert expected_text in wizard.console.log_text
+
+def test_openmm(ad_openmm):
+    inputs = ['system.xml', 'integrator.xml', 'ad.pdb', '10', '10000']
+    wizard = mock_wizard(inputs)
+    with ad_openmm.as_cwd():
+        engine = openmm(wizard)
+    assert engine.n_frames_max == 10000
+    assert engine.n_steps_per_frame == 10

--- a/paths_cli/tests/wizard/test_openmm.py
+++ b/paths_cli/tests/wizard/test_openmm.py
@@ -7,34 +7,6 @@ from paths_cli.wizard.openmm import (
     _load_openmm_xml, _load_topology, openmm
 )
 
-@pytest.fixture
-def ad_openmm(tmpdir):
-    """
-    Provide directory with files to start alanine depeptide sim in OpenMM
-    """
-    mm = pytest.importorskip('simtk.openmm')
-    u = pytest.importorskip('simtk.unit')
-    openmmtools = pytest.importorskip('openmmtools')
-    md = pytest.importorskip('mdtraj')
-    testsystem = openmmtools.testsystems.AlanineDipeptideVacuum()
-    integrator = openmmtools.integrators.VVVRIntegrator(
-        300 * u.kelvin,
-        1.0 / u.picosecond,
-        2.0 * u.femtosecond
-    )
-    traj = md.Trajectory([testsystem.positions.value_in_unit(u.nanometer)],
-                         topology=testsystem.mdtraj_topology)
-    files = {'integrator.xml': integrator,
-             'system.xml': testsystem.system}
-    with tmpdir.as_cwd():
-        for fname, obj in files.items():
-            with open(fname, mode='w') as f:
-                f.write(mm.XmlSerializer.serialize(obj))
-
-        traj.save('ad.pdb')
-
-    return tmpdir
-
 
 @pytest.mark.parametrize('obj_type', ['system', 'integrator', 'foo'])
 def test_load_openmm_xml(ad_openmm, obj_type):

--- a/paths_cli/tests/wizard/test_openmm.py
+++ b/paths_cli/tests/wizard/test_openmm.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from paths_cli.tests.wizard.mock_wizard import mock_wizard
 

--- a/paths_cli/tests/wizard/test_openmm.py
+++ b/paths_cli/tests/wizard/test_openmm.py
@@ -2,11 +2,14 @@ import pytest
 from unittest import mock
 
 from paths_cli.tests.wizard.mock_wizard import mock_wizard
+from paths_cli.tests.utils import assert_url
 
 from paths_cli.wizard.openmm import (
-    _load_openmm_xml, _load_topology, openmm
+    _load_openmm_xml, _load_topology, openmm, OPENMM_SERIALIZATION_URL
 )
 
+def test_helper_url():
+    assert_url(OPENMM_SERIALIZATION_URL)
 
 @pytest.mark.parametrize('obj_type', ['system', 'integrator', 'foo'])
 def test_load_openmm_xml(ad_openmm, obj_type):

--- a/paths_cli/tests/wizard/test_openmm.py
+++ b/paths_cli/tests/wizard/test_openmm.py
@@ -42,7 +42,7 @@ def test_load_topology(ad_openmm, setup):
     with ad_openmm.as_cwd():
         top = _load_topology(wizard)
 
-    assert isinstance(top, paths.engines.openmm.topology.MDTrajTopology)
+    assert isinstance(top, paths.engines.MDTrajTopology)
     assert wizard.console.input_call_count == len(inputs)
     assert expected_text in wizard.console.log_text
 

--- a/paths_cli/tests/wizard/test_shooting.py
+++ b/paths_cli/tests/wizard/test_shooting.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 from functools import partial
 
 from paths_cli.tests.wizard.mock_wizard import mock_wizard

--- a/paths_cli/tests/wizard/test_shooting.py
+++ b/paths_cli/tests/wizard/test_shooting.py
@@ -1,0 +1,67 @@
+import pytest
+import mock
+from functools import partial
+
+from paths_cli.tests.wizard.mock_wizard import mock_wizard
+
+from paths_cli.wizard.shooting import (
+    # selectors
+    uniform_selector, gaussian_selector, _get_selector, SHOOTING_SELECTORS,
+    # shooting algorithms
+    one_way_shooting, spring_shooting,
+    # main func
+    shooting, SHOOTING_TYPES
+)
+
+import openpathsampling as paths
+from openpathsampling.experimental.storage.collective_variables import \
+        CoordinateFunctionCV
+
+def test_uniform_selector():
+    wizard = mock_wizard([])
+    sel = uniform_selector(wizard)
+    assert isinstance(sel, paths.UniformSelector)
+    assert wizard.console.input_call_count == 0
+
+def test_gaussian_selector():
+    wizard = mock_wizard(['x', '1.0', '0.5'])
+    cv = CoordinateFunctionCV(lambda s: s.xyz[0][0]).named('x')
+    wizard.cvs[cv.name] = cv
+    sel = gaussian_selector(wizard)
+    assert isinstance(sel, paths.GaussianBiasSelector)
+    assert sel.alpha == 2.0
+    assert sel.l_0 == 1.0
+
+def test_get_selector():
+    wizard = mock_wizard(['Uniform random'])
+    sel = _get_selector(wizard)
+    assert isinstance(sel, paths.UniformSelector)
+
+def test_one_way_shooting(toy_engine):
+    wizard = mock_wizard(['Uniform random'])
+    wizard.engines[toy_engine.name] = toy_engine
+    strategy = one_way_shooting(wizard)
+    assert isinstance(strategy, paths.strategies.OneWayShootingStrategy)
+    assert isinstance(strategy.selector, paths.UniformSelector)
+    assert strategy.engine == toy_engine
+
+def test_spring_shooting(toy_engine):
+    wizard = mock_wizard(['10', '0.25'])
+    wizard.engines[toy_engine.name] = toy_engine
+    strategy = spring_shooting(wizard)
+    assert isinstance(strategy, partial)
+    assert strategy.func == paths.SpringShootingMoveScheme
+    assert strategy.keywords['delta_max'] == 10
+    assert strategy.keywords['k_spring'] == 0.25
+    assert strategy.keywords['engine'] == toy_engine
+
+@pytest.mark.parametrize('shooting_types', [{}, None])
+def test_shooting(toy_engine, shooting_types):
+    key = 'One-way (stochastic) shooting'
+    wizard = mock_wizard([key])
+    wizard.engines[toy_engine.name] = toy_engine
+    foo = mock.Mock(return_value='foo')
+    if shooting_types == {}:
+        shooting_types = {key: foo}
+    with mock.patch.dict(SHOOTING_TYPES, {key: foo}):
+        assert shooting(wizard, shooting_types=shooting_types) == 'foo'

--- a/paths_cli/tests/wizard/test_tools.py
+++ b/paths_cli/tests/wizard/test_tools.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from paths_cli.wizard.tools import *
 

--- a/paths_cli/tests/wizard/test_tools.py
+++ b/paths_cli/tests/wizard/test_tools.py
@@ -1,0 +1,18 @@
+import pytest
+import mock
+
+from paths_cli.wizard.tools import *
+
+@pytest.mark.parametrize('word,expected', [
+    ('foo', 'a'), ('egg', 'an')
+])
+def test_a_an(word, expected):
+    assert a_an(word) == expected
+
+
+@pytest.mark.parametrize('user_inp,expected', [
+    ('y', True), ('n', False),
+    # ('Y', True), ('N', False), ('yes', True), ('no', False)
+])
+def test_yes_no(user_inp, expected):
+    assert yes_no(user_inp) == expected

--- a/paths_cli/tests/wizard/test_tools.py
+++ b/paths_cli/tests/wizard/test_tools.py
@@ -12,7 +12,7 @@ def test_a_an(word, expected):
 
 @pytest.mark.parametrize('user_inp,expected', [
     ('y', True), ('n', False),
-    # ('Y', True), ('N', False), ('yes', True), ('no', False)
+    ('Y', True), ('N', False), ('yes', True), ('no', False)
 ])
 def test_yes_no(user_inp, expected):
     assert yes_no(user_inp) == expected

--- a/paths_cli/tests/wizard/test_tps.py
+++ b/paths_cli/tests/wizard/test_tps.py
@@ -1,0 +1,43 @@
+import pytest
+import mock
+
+from functools import partial
+
+import openpathsampling as paths
+from openpathsampling import strategies
+
+from paths_cli.tests.wizard.mock_wizard import mock_wizard
+
+from paths_cli.wizard.tps import tps_scheme
+
+
+
+@pytest.fixture
+def tps_network():
+    cv = paths.CoordinateFunctionCV('x', lambda s: s.xyz[0][0])
+    state_A = paths.CVDefinedVolume(cv, float("-inf"), 0).named("A")
+    state_B = paths.CVDefinedVolume(cv, 0, float("inf")).named("B")
+    network = paths.TPSNetwork(state_A, state_B).named('tps-network')
+    return network
+
+@pytest.mark.parametrize('as_scheme', [False, True])
+def test_tps_scheme(tps_network, toy_engine, as_scheme):
+    wizard = mock_wizard([])
+    wizard.networks = {tps_network.name: tps_network}
+    if as_scheme:
+        strategy = partial(paths.SpringShootingMoveScheme,
+                           k_spring=0.01,
+                           delta_max=10,
+                           engine=toy_engine)
+    else:
+        strategy = strategies.OneWayShootingStrategy(
+            selector=paths.UniformSelector(),
+            engine=toy_engine
+        )
+    with mock.patch('paths_cli.wizard.tps.shooting',
+                    new=mock.Mock(return_value=strategy)):
+        scheme = tps_scheme(wizard)
+
+    assert isinstance(scheme, paths.MoveScheme)
+    if as_scheme:
+        assert isinstance(scheme, paths.SpringShootingMoveScheme)

--- a/paths_cli/tests/wizard/test_tps.py
+++ b/paths_cli/tests/wizard/test_tps.py
@@ -10,16 +10,6 @@ from paths_cli.tests.wizard.mock_wizard import mock_wizard
 
 from paths_cli.wizard.tps import tps_scheme
 
-
-
-@pytest.fixture
-def tps_network():
-    cv = paths.CoordinateFunctionCV('x', lambda s: s.xyz[0][0])
-    state_A = paths.CVDefinedVolume(cv, float("-inf"), 0).named("A")
-    state_B = paths.CVDefinedVolume(cv, 0, float("inf")).named("B")
-    network = paths.TPSNetwork(state_A, state_B).named('tps-network')
-    return network
-
 @pytest.mark.parametrize('as_scheme', [False, True])
 def test_tps_scheme(tps_network, toy_engine, as_scheme):
     wizard = mock_wizard([])

--- a/paths_cli/tests/wizard/test_tps.py
+++ b/paths_cli/tests/wizard/test_tps.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from functools import partial
 

--- a/paths_cli/tests/wizard/test_two_state_tps.py
+++ b/paths_cli/tests/wizard/test_two_state_tps.py
@@ -1,0 +1,25 @@
+import pytest
+import mock
+
+from paths_cli.tests.wizard.mock_wizard import mock_wizard
+
+from paths_cli.wizard.two_state_tps import two_state_tps
+
+def mock_tps_scheme(wizard, network):
+    wizard.say(str(network.__class__))
+    return "this would be a scheme"
+
+@mock.patch('paths_cli.wizard.two_state_tps.tps_scheme',
+            new=mock_tps_scheme)
+def test_two_state_tps(tps_network):
+    wizard = mock_wizard([])
+    state_A = tps_network.initial_states[0]
+    state_B = tps_network.final_states[0]
+    with mock.patch('paths_cli.wizard.two_state_tps.volumes',
+                    new=mock.Mock(side_effect=[state_A, state_B])):
+        scheme = two_state_tps(wizard)
+    assert scheme == "this would be a scheme"
+    assert "network.TPSNetwork" in wizard.console.log_text
+
+
+

--- a/paths_cli/tests/wizard/test_two_state_tps.py
+++ b/paths_cli/tests/wizard/test_two_state_tps.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from paths_cli.tests.wizard.mock_wizard import mock_wizard
 

--- a/paths_cli/tests/wizard/test_volumes.py
+++ b/paths_cli/tests/wizard/test_volumes.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from paths_cli.tests.wizard.mock_wizard import mock_wizard
 

--- a/paths_cli/tests/wizard/test_volumes.py
+++ b/paths_cli/tests/wizard/test_volumes.py
@@ -1,0 +1,138 @@
+import pytest
+import mock
+
+from paths_cli.tests.wizard.mock_wizard import mock_wizard
+
+from paths_cli.wizard.volumes import (
+    _vol_intro, intersection_volume, union_volume, negated_volume,
+    cv_defined_volume, volumes, SUPPORTED_VOLUMES
+)
+
+import openpathsampling as paths
+from openpathsampling.experimental.storage.collective_variables import \
+        CoordinateFunctionCV
+
+from openpathsampling.tests.test_helpers import make_1d_traj
+
+def _wrap(x, period_min, period_max):
+    # used in testing periodic CVs
+    while x >= period_max:
+        x -= period_max - period_min
+    while x < period_min:
+        x += period_max - period-min
+    return x
+
+
+@pytest.fixture
+def volume_setup():
+    cv = CoordinateFunctionCV(lambda snap: snap.xyz[0][0]).named('x')
+    vol1 = paths.CVDefinedVolume(cv, 0.0, 1.0)
+    vol2 = paths.CVDefinedVolume(cv, 0.5, 1.5)
+    return vol1, vol2
+
+@pytest.mark.parametrize('as_state,has_state', [
+    (True, False), (True, True), (False, False)
+])
+def test_vol_intro(as_state, has_state):
+    wizard = mock_wizard([])
+    wizard.requirements['state'] = ('states', 2, float('inf'))
+    if has_state:
+        wizard.states['foo'] = 'placeholder'
+
+    intro = _vol_intro(wizard, as_state)
+
+    if as_state and has_state:
+        assert "another stable state" in intro
+    elif as_state and not has_state:
+        assert "You'll need to define" in intro
+    elif not as_state:
+        assert intro is None
+    else:
+        raise RuntimeError("WTF?")
+
+def _binary_volume_test(volume_setup, func):
+    vol1, vol2 = volume_setup
+    wizard = mock_wizard([])
+    mock_volumes = mock.Mock(side_effect=[vol1, vol2])
+    with mock.patch('paths_cli.wizard.volumes.volumes', new=mock_volumes):
+        vol = func(wizard)
+
+    assert "first volume" in wizard.console.log_text
+    assert "second volume" in wizard.console.log_text
+    assert "Created" in wizard.console.log_text
+    return wizard, vol
+
+def test_intersection_volume(volume_setup):
+    wizard, vol = _binary_volume_test(volume_setup, intersection_volume)
+    assert "intersection" in wizard.console.log_text
+    traj = make_1d_traj([0.25, 0.75])
+    assert not vol(traj[0])
+    assert vol(traj[1])
+
+def test_union_volume(volume_setup):
+    wizard, vol = _binary_volume_test(volume_setup, union_volume)
+    assert "union" in wizard.console.log_text
+    traj = make_1d_traj([0.25, 0.75, 1.75])
+    assert vol(traj[0])
+    assert vol(traj[1])
+    assert not vol(traj[2])
+
+def test_negated_volume(volume_setup):
+    init_vol, _ = volume_setup
+    traj = make_1d_traj([0.5, 1.5])
+    assert init_vol(traj[0])
+    assert not init_vol(traj[1])
+    wizard = mock_wizard([])
+    mock_vol = mock.Mock(return_value=init_vol)
+    with mock.patch('paths_cli.wizard.volumes.volumes', new=mock_vol):
+        vol = negated_volume(wizard)
+
+    assert "not in" in wizard.console.log_text
+    assert not vol(traj[0])
+    assert vol(traj[1])
+
+@pytest.mark.parametrize('periodic', [True, False])
+def test_cv_defined_volume(periodic):
+    if periodic:
+        min_ = 0.0
+        max_ = 1.0
+        cv = CoordinateFunctionCV(
+            lambda snap: _wrap(snap.xyz[0][0], period_min=min_,
+                               period_max=max_),
+            period_min=min_, period_max=max_
+        ).named('x')
+        inputs = ['x', '0.75', '1.25']
+        in_state = make_1d_traj([0.2, 0.8])
+        out_state = make_1d_traj([0.5])
+    else:
+        cv = CoordinateFunctionCV(lambda snap: snap.xyz[0][0]).named('x')
+        inputs = ['x', '0.0', '1.0']
+        in_state = make_1d_traj([0.5])
+        out_state = make_1d_traj([-0.1, 1.1])
+    wizard = mock_wizard(inputs)
+    wizard.cvs[cv.name] = cv
+    vol = cv_defined_volume(wizard)
+    assert "interval" in wizard.console.log_text
+    for snap in in_state:
+        assert vol(snap)
+    for snap in out_state:
+        assert not vol(snap)
+
+@pytest.mark.parametrize('intro', [None, "", "foo"])
+def test_volumes(intro):
+    say_hello = mock.Mock(return_value="hello!")
+    wizard = mock_wizard(['Hello world'])
+    with mock.patch.dict(SUPPORTED_VOLUMES, {'Hello world': say_hello}):
+        assert volumes(wizard, intro=intro) == "hello!"
+        assert wizard.console.input_call_count == 1
+
+
+    n_statements = 2 * (1 + 3)
+    # 2: line and blank; (1 + 3): 1 in volumes + 3 in ask_enumerate
+
+    if intro == 'foo':
+        assert 'foo' in wizard.console.log_text
+        assert len(wizard.console.log) == n_statements + 2  # from intro
+    else:
+        assert 'foo' not in wizard.console.log_text
+        assert len(wizard.console.log) == n_statements

--- a/paths_cli/tests/wizard/test_wizard.py
+++ b/paths_cli/tests/wizard/test_wizard.py
@@ -303,6 +303,9 @@ class TestWizard:
         assert len(self.wizard.engines) == 0
 
     def test_run_wizard(self, toy_engine):
+        # skip patching the wizard; we never actually use the saving
+        # mechanisms and don't want to unpatch after
+        self.wizard._patched = True
         step = mock.Mock(
             func=mock.Mock(return_value=toy_engine),
             display_name='Engine',

--- a/paths_cli/tests/wizard/test_wizard.py
+++ b/paths_cli/tests/wizard/test_wizard.py
@@ -197,7 +197,7 @@ class TestWizard:
         assert line == expected
 
     def test_save_to_file(self):
-        pass
+        pytest.skip()
 
     @pytest.mark.parametrize('req,count,expected', [
         (('cvs', 1, 1), 0, (True, True)),
@@ -222,5 +222,8 @@ class TestWizard:
         if len(inputs) > 1:
             assert "Sorry" in console.log_text
 
+    def test_do_one(self):
+        pytest.skip()
+
     def test_run_wizard(self):
-        pass
+        pytest.skip()

--- a/paths_cli/tests/wizard/test_wizard.py
+++ b/paths_cli/tests/wizard/test_wizard.py
@@ -1,7 +1,7 @@
 import pytest
 import mock
 from paths_cli.tests.wizard.mock_wizard import (
-    make_mock_wizard, make_mock_retry_wizard
+    MockConsole
 )
 import pathlib
 
@@ -10,30 +10,6 @@ from openpathsampling.experimental.storage.collective_variables import \
 
 from paths_cli.wizard.wizard import *
 
-class MockConsole:
-    def __init__(self, inputs=None):
-        if isinstance(inputs, str):
-            inputs = [inputs]
-        elif inputs is None:
-            inputs = []
-        self.inputs = inputs
-        self._input_iter = iter(inputs)
-        self.log = []
-        self.width = 80
-        self.input_call_count = 0
-
-    def print(self, content=""):
-        self.log.append(content)
-
-    def input(self, content):
-        self.input_call_count += 1
-        user_input = next(self._input_iter)
-        self.log.append(content + " " + user_input)
-        return user_input
-
-    @property
-    def log_text(self):
-        return "\n".join(self.log)
 
 
 class TestWizard:

--- a/paths_cli/tests/wizard/test_wizard.py
+++ b/paths_cli/tests/wizard/test_wizard.py
@@ -72,7 +72,14 @@ class TestWizard:
         assert 'bar' in console.log_text
 
     def test_ask_help(self):
-        pass
+        console = MockConsole(['?helpme', 'foo'])
+        self.wizard.console = console
+        def helper(wizard, result):
+            wizard.say(f"You said: {result[1:]}")
+
+        result = self.wizard.ask('bar', helper=helper)
+        assert result == 'foo'
+        assert 'You said: helpme' in console.log_text
 
     def _generic_speak_test(self, func_name):
         console = MockConsole()

--- a/paths_cli/tests/wizard/test_wizard.py
+++ b/paths_cli/tests/wizard/test_wizard.py
@@ -1,0 +1,234 @@
+import pytest
+import mock
+from paths_cli.tests.wizard.mock_wizard import (
+    make_mock_wizard, make_mock_retry_wizard
+)
+import pathlib
+
+from openpathsampling.experimental.storage.collective_variables import \
+        CoordinateFunctionCV
+
+from paths_cli.wizard.wizard import *
+
+class MockConsole:
+    def __init__(self, inputs=None):
+        if isinstance(inputs, str):
+            inputs = [inputs]
+        elif inputs is None:
+            inputs = []
+        self.inputs = inputs
+        self._input_iter = iter(inputs)
+        self.log = []
+        self.width = 80
+        self.input_call_count = 0
+
+    def print(self, content=""):
+        self.log.append(content)
+
+    def input(self, content):
+        self.input_call_count += 1
+        user_input = next(self._input_iter)
+        self.log.append(content + " " + user_input)
+        return user_input
+
+    @property
+    def log_text(self):
+        return "\n".join(self.log)
+
+
+class TestWizard:
+    def setup(self):
+        self.wizard = Wizard([])
+
+    def test_initialization(self):
+        wizard = Wizard([SINGLE_ENGINE_STEP])
+        assert wizard.requirements == {'engine': ('engines', 1, 1)}
+
+    def test_ask(self):
+        console = MockConsole('foo')
+        self.wizard.console = console
+        result = self.wizard.ask('bar')
+        assert result == 'foo'
+        assert 'bar' in console.log_text
+
+    def test_ask_help(self):
+        pass
+
+    def _generic_speak_test(self, func_name):
+        console = MockConsole()
+        self.wizard.console = console
+        func = getattr(self.wizard, func_name)
+        func('foo')
+        assert 'foo' in console.log_text
+
+    def test_say(self):
+        self._generic_speak_test('say')
+
+    def test_start(self):
+        self._generic_speak_test('start')
+
+    def test_bad_input(self):
+        self._generic_speak_test('bad_input')
+
+    @pytest.mark.parametrize('bad_choice', [False, True])
+    def test_ask_enumerate(self, bad_choice):
+        inputs = {False: '1', True: ['10', '1']}[bad_choice]
+        console = MockConsole(inputs)
+        self.wizard.console = console
+        selected = self.wizard.ask_enumerate('foo', options=['bar', 'baz'])
+        assert selected == 'bar'
+        assert 'foo' in console.log_text
+        assert '1. bar' in console.log_text
+        assert '2. baz' in console.log_text
+        assert console.input_call_count == len(inputs)
+        if bad_choice:
+            assert "'10'" in console.log_text
+            assert 'not a valid option' in console.log_text
+        else:
+            assert "'10'" not in console.log_text
+            assert 'not a valid option' not in console.log_text
+
+    @pytest.mark.parametrize('inputs, type_, expected', [
+        ("2+2", int, 4), ("0.1 * 0.1", float, 0.1*0.1), ("2.4", int, 2)
+    ])
+    def test_ask_custom_eval(self, inputs, type_, expected):
+        console = MockConsole(inputs)
+        self.wizard.console = console
+        result = self.wizard.ask_custom_eval('foo', type_=type_)
+        assert result == expected
+        assert console.input_call_count == 1
+        assert 'foo' in console.log_text
+
+    def test_ask_custom_eval_bad_type(self):
+        console = MockConsole(['"bar"', '2+2'])
+        self.wizard.console = console
+        result = self.wizard.ask_custom_eval('foo')
+        assert result == 4
+        assert console.input_call_count == 2
+        assert "I couldn't understand" in console.log_text
+        assert "ValueError" in console.log_text
+
+    def test_ask_custom_eval_bad_input(self):
+        console = MockConsole(['bar', '2+2'])
+        self.wizard.console = console
+        result = self.wizard.ask_custom_eval('foo')
+        assert result == 4
+        assert console.input_call_count == 2
+        assert "I couldn't understand" in console.log_text
+        assert "NameError" in console.log_text
+
+    @pytest.mark.parametrize('inputs,expected', [('1', 'bar'),
+                                                 ('2', 'new')])
+    def test_obj_selector(self, inputs, expected):
+        create_func = lambda wiz: 'new'
+        console = MockConsole(inputs)
+        self.wizard.console = console
+        self.wizard.cvs = {'foo': 'bar'}
+        def mock_register(obj, name, store):
+            console.print("registered")
+            return obj
+        self.wizard.register = mock_register
+        sel = self.wizard.obj_selector('cvs', "CV", create_func)
+        assert sel == expected
+        assert "CV" in console.log_text
+        if inputs == '2':
+            assert "registered" in console.log_text
+
+    def test_exception(self):
+        console = MockConsole()
+        self.wizard.console = console
+        err = RuntimeError("baz")
+        self.wizard.exception('foo', err)
+        assert 'foo' in console.log_text
+        assert "RuntimeError: baz" in console.log_text
+
+    def test_name(self):
+        # why does that exist? cf core.name
+        # actually, it looks like we never use core.name; remove that and
+        # move its test here?
+        pass
+
+    @pytest.mark.parametrize('named', [True, False])
+    def test_register(self, named):
+        cv = CoordinateFunctionCV(lambda s: s.xyz[0][0])
+        if named:
+            cv = cv.named('foo')
+        do_naming = lambda obj, obj_type, store_name: cv.named('foo')
+        assert cv.is_named == named
+        self.wizard.name = mock.Mock(side_effect=do_naming)
+        assert len(self.wizard.cvs) == 0
+        self.wizard.register(cv, 'CV', 'cvs')
+        assert len(self.wizard.cvs) == 1
+        assert cv.name == 'foo'
+
+    def _get_storage(self, inputs, expected):
+        console = MockConsole(inputs)
+        self.wizard.console = console
+        storage = self.wizard.get_storage()
+        assert storage.backend.filename == expected
+        assert console.input_call_count == len(inputs)
+
+    @pytest.mark.parametrize('fnames', [(['setup.db']),
+                                        (['setup.nc', 'setup.db'])])
+    def test_get_storage(self, tmpdir, fnames):
+        inputs = [os.path.join(tmpdir, inp) for inp in fnames]
+        self._get_storage(inputs, inputs[-1])
+
+    @pytest.mark.parametrize('overwrite', [True, False])
+    def test_get_storage_exists(self, overwrite, tmpdir):
+        inputs = [os.path.join(tmpdir, 'setup.db'),
+                  {True: 'y', False: 'n'}[overwrite]]
+        if not overwrite:
+            inputs.append(os.path.join(tmpdir, 'setup2.db'))
+
+        pathlib.Path(inputs[0]).touch()
+        expected = 'setup.db' if overwrite else 'setup2.db'
+        self._get_storage(inputs, os.path.join(tmpdir, expected))
+
+    def test_get_storage_file_error(self, tmpdir):
+        inputs = ['/oogabooga/foo/bar.db', os.path.join(tmpdir, 'setup.db')]
+        self._get_storage(inputs, inputs[-1])
+
+    @pytest.mark.parametrize('count', [0, 1, 2])
+    def test_storage_description_line(self, count):
+        from openpathsampling.experimental.storage.collective_variables \
+                import CoordinateFunctionCV
+        expected = {0: "",
+                    1: "* 1 cv: ['foo']",
+                    2: "* 2 cvs: ['foo', 'bar']"}[count]
+
+        self.wizard.cvs = {
+            name: CoordinateFunctionCV(lambda s: s.xyz[0][0]).named(name)
+            for name in ['foo', 'bar'][:count]
+        }
+        line = self.wizard._storage_description_line('cvs')
+        assert line == expected
+
+    def test_save_to_file(self):
+        pass
+
+    @pytest.mark.parametrize('req,count,expected', [
+        (('cvs', 1, 1), 0, (True, True)),
+        (('cvs', 1, 1), 1, (False, False)),
+        (('cvs', 1, 2), 1, (False, True)),
+        ((None, 0, 0), 0, (True, False))
+    ])
+    def test_req_do_another(self, req, count, expected):
+        self.wizard.cvs = {str(i): 'foo' for i in range(count)}
+        assert self.wizard._req_do_another(req) == expected
+
+    @pytest.mark.parametrize('inputs,expected', [
+        (['y'], True), (['z', 'y'], True), (['z', 'n'], False),
+        (['n'], False)
+    ])
+    def test_ask_do_another(self, inputs, expected):
+        console = MockConsole(inputs)
+        self.wizard.console = console
+        result = self.wizard._ask_do_another("CV")
+        assert result == expected
+        assert "another CV" in console.log_text
+        if len(inputs) > 1:
+            assert "Sorry" in console.log_text
+
+    def test_run_wizard(self):
+        pass

--- a/paths_cli/tests/wizard/test_wizard.py
+++ b/paths_cli/tests/wizard/test_wizard.py
@@ -9,6 +9,7 @@ from openpathsampling.experimental.storage.collective_variables import \
         CoordinateFunctionCV
 
 from paths_cli.wizard.wizard import *
+from paths_cli.wizard.steps import SINGLE_ENGINE_STEP
 
 
 

--- a/paths_cli/tests/wizard/test_wizard.py
+++ b/paths_cli/tests/wizard/test_wizard.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 from paths_cli.tests.wizard.mock_wizard import (
     MockConsole, make_mock_wizard, make_mock_retry_wizard
 )

--- a/paths_cli/tests/wizard/test_wizard.py
+++ b/paths_cli/tests/wizard/test_wizard.py
@@ -1,7 +1,7 @@
 import pytest
 import mock
 from paths_cli.tests.wizard.mock_wizard import (
-    MockConsole
+    MockConsole, make_mock_wizard, make_mock_retry_wizard
 )
 import pathlib
 
@@ -120,10 +120,25 @@ class TestWizard:
         assert "RuntimeError: baz" in console.log_text
 
     def test_name(self):
-        # why does that exist? cf core.name
-        # actually, it looks like we never use core.name; remove that and
-        # move its test here?
-        pass
+        wizard = make_mock_wizard('foo')
+        cv = CoordinateFunctionCV(lambda s: s.xyz[0][0])
+        assert not cv.is_named
+        result = wizard.name(cv, obj_type="CV", store_name="cvs")
+        assert result is cv
+        assert result.is_named
+        assert result.name == 'foo'
+
+    def test_name_exists(self):
+        wizard = make_mock_retry_wizard(['foo', 'bar'])
+        wizard.cvs['foo'] = 'placeholder'
+        cv = CoordinateFunctionCV(lambda s: s.xyz[0][0])
+        assert not cv.is_named
+        result = wizard.name(cv, obj_type="CV", store_name="cvs")
+        assert result is cv
+        assert result.is_named
+        assert result.name == 'bar'
+        assert wizard.console.input.call_count == 2
+
 
     @pytest.mark.parametrize('named', [True, False])
     def test_register(self, named):

--- a/paths_cli/wizard/core.py
+++ b/paths_cli/wizard/core.py
@@ -13,12 +13,12 @@ def interpret_req(req):
         return str(min_)
 
     if min_ >= 1:
-        string += "at least " + str(min_)
+        string += f"at least {min_}"
 
     if max_ < float("inf"):
-        if string != "":
+        if string:
             string += " and "
-        string += "at most " + str(max_)
+        string += f"at most {max_}"
 
     return string
 
@@ -43,5 +43,4 @@ def get_object(func):
             obj = func(*args, **kwargs)
         return obj
     return inner
-
 

--- a/paths_cli/wizard/core.py
+++ b/paths_cli/wizard/core.py
@@ -35,7 +35,18 @@ def abort_retry_quit(wizard, obj_type):
 
 
 def interpret_req(req):
-    _, num, direction = req
-    dir_str = {'+': 'at least ', '=': '', '-': 'at most '}[direction]
-    return dir_str + str(num)
+    _, min_, max_ = req
+    string = ""
+    if min_ == max_:
+        return str(min_)
+
+    if min_ >= 1:
+        string += "at least " + str(min_)
+
+    if max_ < float("inf"):
+        if string != "":
+            string += " and "
+        string += "at most " + str(max_)
+
+    return string
 

--- a/paths_cli/wizard/core.py
+++ b/paths_cli/wizard/core.py
@@ -2,6 +2,10 @@ import random
 from paths_cli.wizard.joke import name_joke
 from paths_cli.wizard.tools import a_an
 
+from collections import namedtuple
+
+WizardSay = namedtuple("WizardSay", ['msg', 'mode'])
+
 def name(wizard, obj, obj_type, store_name, default=None):
     wizard.say(f"Now let's name your {obj_type}.")
     name = None
@@ -72,3 +76,5 @@ def get_object(func):
             obj = func(*args, **kwargs)
         return obj
     return inner
+
+

--- a/paths_cli/wizard/core.py
+++ b/paths_cli/wizard/core.py
@@ -6,39 +6,6 @@ from collections import namedtuple
 
 WizardSay = namedtuple("WizardSay", ['msg', 'mode'])
 
-def name(wizard, obj, obj_type, store_name, default=None):
-    wizard.say(f"Now let's name your {obj_type}.")
-    name = None
-    while name is None:
-        name = wizard.ask("What do you want to call it?")
-        if name in getattr(wizard, store_name):
-            wizard.bad_input(f"Sorry, you already have {a_an(obj_type)} "
-                             f"{obj_type} named {name}. Please try another "
-                             "name.")
-            name = None
-
-    obj = obj.named(name)
-
-    wizard.say(f"'{name}' is a good name for {a_an(obj_type)} {obj_type}. "
-               + name_joke(name, obj_type))
-    return obj
-
-def abort_retry_quit(wizard, obj_type):
-    a_an = a_an(obj_type)
-    retry = wizard.ask(f"Do you want to try again to make {a_an} "
-                       f"{obj_type}, do you want to continue without, or "
-                       f"do you want to quit?",
-                       options=["[R]etry", "[C]ontinue", "[Q]uit"])
-    if retry == 'q':
-        exit()
-    elif retry == 'r':
-        return
-    elif retry == 'c':
-        return "continue"
-    else:
-        raise ImpossibleError()
-
-
 def interpret_req(req):
     _, min_, max_ = req
     string = ""

--- a/paths_cli/wizard/core.py
+++ b/paths_cli/wizard/core.py
@@ -1,6 +1,6 @@
 import random
-from joke import name_joke
-from tools import a_an
+from paths_cli.wizard.joke import name_joke
+from paths_cli.wizard.tools import a_an
 
 def name(wizard, obj, obj_type, store_name, default=None):
     wizard.say(f"Now let's name your {obj_type}.")
@@ -9,7 +9,8 @@ def name(wizard, obj, obj_type, store_name, default=None):
         name = wizard.ask("What do you want to call it?")
         if name in getattr(wizard, store_name):
             wizard.bad_input(f"Sorry, you already have {a_an(obj_type)} "
-                             f"named {name}. Please try another name.")
+                             f"{obj_type} named {name}. Please try another "
+                             "name.")
             name = None
 
     obj = obj.named(name)
@@ -19,7 +20,7 @@ def name(wizard, obj, obj_type, store_name, default=None):
     return obj
 
 def abort_retry_quit(wizard, obj_type):
-    a_an = 'an' if obj_type[0] in 'aeiou' else 'a'
+    a_an = a_an(obj_type)
     retry = wizard.ask(f"Do you want to try again to make {a_an} "
                        f"{obj_type}, do you want to continue without, or "
                        f"do you want to quit?",
@@ -60,6 +61,6 @@ def get_missing_object(wizard, obj_dict, display_name, fallback_func):
         objs = list(obj_dict.keys())
         sel = wizard.ask_enumerate(f"Which {display_name} would you like "
                                    "to use?", options=objs)
-        obj = objs[sel]
+        obj = obj_dict[sel]
     return obj
 

--- a/paths_cli/wizard/core.py
+++ b/paths_cli/wizard/core.py
@@ -1,9 +1,9 @@
 import random
-from paths_cli.wizard.joke import name_joke
 from paths_cli.wizard.tools import a_an
 
 from collections import namedtuple
 
+WIZARD_STORE_NAMES = ['engines', 'cvs', 'states', 'networks', 'schemes']
 WizardSay = namedtuple("WizardSay", ['msg', 'mode'])
 
 def interpret_req(req):

--- a/paths_cli/wizard/core.py
+++ b/paths_cli/wizard/core.py
@@ -64,3 +64,11 @@ def get_missing_object(wizard, obj_dict, display_name, fallback_func):
         obj = obj_dict[sel]
     return obj
 
+
+def get_object(func):
+    def inner(*args, **kwargs):
+        obj = None
+        while obj is None:
+            obj = func(*args, **kwargs)
+        return obj
+    return inner

--- a/paths_cli/wizard/core.py
+++ b/paths_cli/wizard/core.py
@@ -1,0 +1,41 @@
+import random
+from joke import name_joke
+from tools import a_an
+
+def name(wizard, obj, obj_type, store_name, default=None):
+    wizard.say(f"Now let's name your {obj_type}.")
+    name = None
+    while name is None:
+        name = wizard.ask("What do you want to call it?")
+        if name in getattr(wizard, store_name):
+            wizard.bad_input(f"Sorry, you already have {a_an(obj_type)} "
+                             f"named {name}. Please try another name.")
+            name = None
+
+    obj = obj.named(name)
+
+    wizard.say(f"'{name}' is a good name for {a_an(obj_type)} {obj_type}. "
+               + name_joke(name, obj_type))
+    return obj
+
+def abort_retry_quit(wizard, obj_type):
+    a_an = 'an' if obj_type[0] in 'aeiou' else 'a'
+    retry = wizard.ask(f"Do you want to try again to make {a_an} "
+                       f"{obj_type}, do you want to continue without, or "
+                       f"do you want to quit?",
+                       options=["[R]etry", "[C]ontinue", "[Q]uit"])
+    if retry == 'q':
+        exit()
+    elif retry == 'r':
+        return
+    elif retry == 'c':
+        return "continue"
+    else:
+        raise ImpossibleError()
+
+
+def interpret_req(req):
+    _, num, direction = req
+    dir_str = {'+': 'at least ', '=': '', '-': 'at most '}[direction]
+    return dir_str + str(num)
+

--- a/paths_cli/wizard/core.py
+++ b/paths_cli/wizard/core.py
@@ -50,3 +50,16 @@ def interpret_req(req):
 
     return string
 
+
+def get_missing_object(wizard, obj_dict, display_name, fallback_func):
+    if len(obj_dict) == 0:
+        obj = fallback_func(wizard)
+    elif len(obj_dict) == 1:
+        obj = list(obj_dict.values())[0]
+    else:
+        objs = list(obj_dict.keys())
+        sel = wizard.ask_enumerate(f"Which {display_name} would you like "
+                                   "to use?", options=objs)
+        obj = objs[sel]
+    return obj
+

--- a/paths_cli/wizard/cvs.py
+++ b/paths_cli/wizard/cvs.py
@@ -2,6 +2,8 @@ from paths_cli.wizard.engines import engines
 from paths_cli.parsing.tools import custom_eval
 from paths_cli.wizard.load_from_ops import load_from_ops
 from paths_cli.wizard.load_from_ops import LABEL as _load_label
+from paths_cli.wizard.core import get_object
+
 from functools import partial
 import numpy as np
 
@@ -28,65 +30,67 @@ def mdtraj_atom_helper(wizard, user_input, n_atoms):  # no-cov
 def _get_topology(wizard):
     from paths_cli.wizard.engines import engines
     topology = None
-    # TODO: isn't this get_missing_object?
-    while topology is None:
-        if len(wizard.engines) == 0:
-            # SHOULD NEVER GET HERE
-            wizard.say("Hey, you need to define an MD engine before you "
-                       "create CVs that refer to it. Let's do that now!")
-            engine = engines(wizard)
-            wizard.register(engine, 'engine', 'engines')
-            wizard.say("Now let's get back to defining your CV")
-        elif len(wizard.engines) == 1:
-            topology = list(wizard.engines.values())[0].topology
-        else:
-            engines = list(wizard.engines.keys)
-            name = wizard.ask("You have defined multiple engines. Which one "
-                              "should I use to define your CV?",
-                              options=engines)
-            topology = wizard.engines[name].topology
+    # TODO: this is very similar to get_missing_object, but has more
+    # reporting; is there some way to add the reporting to
+    # get_missing_object?
+    if len(wizard.engines) == 0:
+        # SHOULD NEVER GET HERE IF WIZARDS ARE DESIGNED CORRECTLY
+        wizard.say("Hey, you need to define an MD engine before you "
+                   "create CVs that refer to it. Let's do that now!")
+        engine = engines(wizard)
+        wizard.register(engine, 'engine', 'engines')
+        wizard.say("Now let's get back to defining your CV.")
+        topology = engine.topology
+    elif len(wizard.engines) == 1:
+        topology = list(wizard.engines.values())[0].topology
+    else:
+        wizard.say("You have defined multiple engines, and need to pick "
+                   "one to use to get a the topology for your CV.")
+        engine = wizard.obj_selector('engines', 'engine', engines)
+        topology = engine.topology
+        wizard.say("Now let's get back to defining your CV.")
 
     return topology
 
+@get_object
 def _get_atom_indices(wizard, topology, n_atoms, cv_user_str):
-    arr = None
     helper = partial(mdtraj_atom_helper, n_atoms=n_atoms)
-    while arr is None:
-        # switch to get_custom_eval
-        atoms_str = wizard.ask(f"Which atoms do you want to {cv_user_str}?",
-                               helper=helper)
-        try:
-            indices = custom_eval(atoms_str)
-        except Exception as e:
-            wizard.exception(f"Sorry, I did't understand '{atoms_str}'.", e)
-            mdtraj_atom_helper(wizard, '?', n_atoms)
-            continue
+    # switch to get_custom_eval
+    atoms_str = wizard.ask(f"Which atoms do you want to {cv_user_str}?",
+                           helper=helper)
+    try:
+        indices = custom_eval(atoms_str)
+    except Exception as e:
+        wizard.exception(f"Sorry, I did't understand '{atoms_str}'.", e)
+        mdtraj_atom_helper(wizard, '?', n_atoms)
+        return
 
-        try:
-            # move this logic to parsing.tools
-            arr = np.array(indices)
-            if arr.dtype != int:
-                raise TypeError("Input is not integers")
-            if arr.shape != (1, n_atoms):
-                # try to clean it up
-                if len(arr.shape) == 1 and arr.shape[0] ==  n_atoms:
-                    arr.shape = (1, n_atoms)
-                else:
-                    raise TypeError(f"Invalid input. Requires {n_atoms} "
-                                    "atoms.")
-        except Exception as e:
-            wizard.exception(f"Sorry, I did't understand '{atoms_str}'", e)
-            mdtraj_atom_helper(wizard, '?', n_atoms)
-            arr = None
-            continue
+    try:
+        # move this logic to parsing.tools
+        arr = np.array(indices)
+        if arr.dtype != int:
+            raise TypeError("Input is not integers")
+        if arr.shape != (1, n_atoms):
+            # try to clean it up
+            if len(arr.shape) == 1 and arr.shape[0] ==  n_atoms:
+                arr.shape = (1, n_atoms)
+            else:
+                raise TypeError(f"Invalid input. Requires {n_atoms} "
+                                "atoms.")
+    except Exception as e:
+        wizard.exception(f"Sorry, I did't understand '{atoms_str}'", e)
+        mdtraj_atom_helper(wizard, '?', n_atoms)
+        return
 
     return arr
 
+
 def _mdtraj_function_cv(wizard, cv_does_str, cv_user_prompt, func,
-                        kwarg_name, n_atoms):
+                        kwarg_name, n_atoms, period):
     from openpathsampling.experimental.storage.collective_variables import \
             MDTrajFunctionCV
     wizard.say(f"We'll make a CV that measures the {cv_does_str}.")
+    period_min, period_max = period
     topology = _get_topology(wizard)
     indices = _get_atom_indices(wizard, topology, n_atoms=n_atoms,
                                 cv_user_str=cv_user_prompt)
@@ -99,7 +103,8 @@ def _mdtraj_function_cv(wizard, cv_does_str, cv_user_prompt, func,
                "  Topology: " + repr(topology.mdtraj))
     wizard.say(summary)
 
-    return MDTrajFunctionCV(func, topology, **kwargs)
+    return MDTrajFunctionCV(func, topology, period_min=period_min,
+                            period_max=period_max, **kwargs)
 
 def distance(wizard):
     return _mdtraj_function_cv(
@@ -108,7 +113,8 @@ def distance(wizard):
         cv_user_prompt="measure the distance between",
         func=md.compute_distances,
         kwarg_name='atom_pairs',
-        n_atoms=2
+        n_atoms=2,
+        period=(None, None)
     )
 
 def angle(wizard):
@@ -118,7 +124,8 @@ def angle(wizard):
         cv_user_prompt="use to define the angle",
         func=md.compute_angles,
         kwarg_name='angle_indices',
-        n_atoms=3
+        n_atoms=3,
+        period=(-np.pi, np.pi)
     )
 
 def dihedral(wizard):
@@ -128,13 +135,15 @@ def dihedral(wizard):
         cv_user_prompt="use to define the dihedral angle",
         func=md.compute_dihedrals,
         kwarg_name='indices',
-        n_atoms=4
+        n_atoms=4,
+        period=(-np.pi, np.pi)
     )
 
 def rmsd(wizard):
     raise NotImplementedError("RMSD has not yet been implemented")
 
 def coordinate(wizard):
+    # TODO: atom_index should be from wizard.ask_custom_eval
     atom_index = coord = None
     while atom_index is None:
         idx = wizard.ask("For which atom do you want to get the "
@@ -152,6 +161,27 @@ def coordinate(wizard):
             coord = {'x': 0, 'y': 1, 'z': 2}[xyz]
         except KeyError as e:
             wizard.bad_input("Please select one of 'x', 'y', or 'z'")
+
+def _get_period(wizard):
+    # to be used in custom CVs ... or maybe just in the file CV itself?
+    is_periodic = period_min = period_max = None
+    while is_periodic is None:
+        is_periodic_char = wizard.ask("Is this CV periodic?",
+                                      options=["[Y]es", "[N]o"])
+        is_periodic = {'y': True, 'n': False}[is_periodic_char]
+
+    if is_periodic:
+        while period_min is None:
+            period_min = wizard.ask_custom_eval(
+                "What is the lower bound of the period?"
+            )
+        while period_max is None:
+            period_max = wizard.ask_custom_eval(
+                "What is the upper bound of the period?"
+            )
+    return period_min, period_max
+
+
 
 SUPPORTED_CVS = {}
 

--- a/paths_cli/wizard/cvs.py
+++ b/paths_cli/wizard/cvs.py
@@ -158,12 +158,12 @@ if HAS_MDTRAJ:
         'Distance': distance,
         'Angle': angle,
         'Dihedral': dihedral,
-        'RMSD': rmsd,
+        # 'RMSD': rmsd,
     })
 
 SUPPORTED_CVS.update({
     'Coordinate': coordinate,
-    'Python script': ...,
+    # 'Python script': ...,
     _load_label: partial(load_from_ops,
                          store_name='cvs',
                          obj_name='CV'),

--- a/paths_cli/wizard/cvs.py
+++ b/paths_cli/wizard/cvs.py
@@ -80,10 +80,10 @@ def _mdtraj_function_cv(wizard, cv_does_str, cv_user_prompt, func,
     kwargs = {kwarg_name: indices}
 
     summary = ("Here's what we'll create:\n"
-               "  Function: " + str(func.__name__) + "\n"
-               "     Atoms: " + " ".join([str(topology.mdtraj.atom(i))
-                                          for i in indices[0]]) + "\n"
-               "  Topology: " + repr(topology.mdtraj))
+               f"  Function: {func.__name__}\n"
+               f"     Atoms: {" ".join([str(topology.mdtraj.atom(i))
+                                        for i in indices[0]])} \n"
+               f"  Topology: {repr(topology.mdtraj))}"
     wizard.say(summary)
 
     return MDTrajFunctionCV(func, topology, period_min=period_min,

--- a/paths_cli/wizard/cvs.py
+++ b/paths_cli/wizard/cvs.py
@@ -151,27 +151,6 @@ def coordinate(wizard):
     return cv
 
 
-def _get_period(wizard):
-    # to be used in custom CVs ... or maybe just in the file CV itself?
-    is_periodic = period_min = period_max = None
-    while is_periodic is None:
-        is_periodic_char = wizard.ask("Is this CV periodic?",
-                                      options=["[Y]es", "[N]o"])
-        is_periodic = {'y': True, 'n': False}[is_periodic_char]
-
-    if is_periodic:
-        while period_min is None:
-            period_min = wizard.ask_custom_eval(
-                "What is the lower bound of the period?"
-            )
-        while period_max is None:
-            period_max = wizard.ask_custom_eval(
-                "What is the upper bound of the period?"
-            )
-    return period_min, period_max
-
-
-
 SUPPORTED_CVS = {}
 
 if HAS_MDTRAJ:

--- a/paths_cli/wizard/cvs.py
+++ b/paths_cli/wizard/cvs.py
@@ -12,7 +12,7 @@ except ImportError:
 else:
     HAS_MDTRAJ = True
 
-def mdtraj_atom_helper(wizard, user_input, n_atoms):
+def mdtraj_atom_helper(wizard, user_input, n_atoms):  # no-cov
     wizard.say("You should specify atom indices enclosed in double "
                "brackets, e.g, [" + str(list(range(n_atoms))) + "]")
     # TODO: implement the following:
@@ -28,6 +28,7 @@ def mdtraj_atom_helper(wizard, user_input, n_atoms):
 def _get_topology(wizard):
     from paths_cli.wizard.engines import engines
     topology = None
+    # TODO: isn't this get_missing_object?
     while topology is None:
         if len(wizard.engines) == 0:
             # SHOULD NEVER GET HERE
@@ -48,10 +49,10 @@ def _get_topology(wizard):
     return topology
 
 def _get_atom_indices(wizard, topology, n_atoms, cv_user_str):
-    # TODO: move the logic here to parsing.tools
     arr = None
     helper = partial(mdtraj_atom_helper, n_atoms=n_atoms)
     while arr is None:
+        # switch to get_custom_eval
         atoms_str = wizard.ask(f"Which atoms do you want to {cv_user_str}?",
                                helper=helper)
         try:
@@ -62,6 +63,7 @@ def _get_atom_indices(wizard, topology, n_atoms, cv_user_str):
             continue
 
         try:
+            # move this logic to parsing.tools
             arr = np.array(indices)
             if arr.dtype != int:
                 raise TypeError("Input is not integers")

--- a/paths_cli/wizard/cvs.py
+++ b/paths_cli/wizard/cvs.py
@@ -1,0 +1,186 @@
+from paths_cli.wizard.engines import engines
+from paths_cli.parsing.tools import custom_eval
+from paths_cli.wizard.load_from_ops import load_from_ops
+from paths_cli.wizard.load_from_ops import LABEL as _load_label
+from functools import partial
+import numpy as np
+
+try:
+    import mdtraj as md
+except ImportError:
+    HAS_MDTRAJ = False
+else:
+    HAS_MDTRAJ = True
+
+def mdtraj_atom_helper(wizard, user_input, n_atoms):
+    wizard.say("You should specify atom indices enclosed in double "
+               "brackets, e.g, [" + str(list(range(n_atoms))) + "]")
+    # TODO: implement the following:
+    # wizard.say("You can specify atoms either as atom indices (which count "
+               # "from zero) or as atom labels of the format "
+               # "CHAIN:RESIDUE-ATOM, e.g., '0:ALA1-CA' for the alpha carbon "
+               # "of alanine 1 (this time counting from one, as in the PDB) "
+               # "of the 0th chain in the topology. You can also use letters "
+               # "for chain IDs, but note that A corresponds to the first "
+               # "chain in your topology, even if its name in the PDB file "
+               # "is B.")
+
+def _get_topology(wizard):
+    from paths_cli.wizard.engines import engines
+    topology = None
+    while topology is None:
+        if len(wizard.engines) == 0:
+            # SHOULD NEVER GET HERE
+            wizard.say("Hey, you need to define an MD engine before you "
+                       "create CVs that refer to it. Let's do that now!")
+            engine = engines(wizard)
+            wizard.register(engine, 'engine', 'engines')
+            wizard.say("Now let's get back to defining your CV")
+        elif len(wizard.engines) == 1:
+            topology = list(wizard.engines.values())[0].topology
+        else:
+            engines = list(wizard.engines.keys)
+            name = wizard.ask("You have defined multiple engines. Which one "
+                              "should I use to define your CV?",
+                              options=engines)
+            topology = wizard.engines[name].topology
+
+    return topology
+
+def _get_atom_indices(wizard, topology, cv_type):
+    # TODO: move the logic here to parsing.tools
+    n_atoms = {'distance': 2,
+               'angle': 3,
+               'dihedral': 4}[cv_type]
+    arr = None
+    helper = partial(mdtraj_atom_helper, n_atoms=n_atoms)
+    while arr is None:
+        atoms_str = wizard.ask("Which atoms do you want to measure the "
+                               "{cv_type} between?", helper=helper)
+        try:
+            indices = custom_eval(atoms_str)
+        except Exception as e:
+            wizard.exception(f"Sorry, I did't understand '{atoms_str}'", e)
+            mdtraj_atom_helper(wizard, '?', n_atoms)
+            continue
+
+        try:
+            arr = np.array(indices)
+            if arr.dtype != int:
+                raise TypeError("Input is not integers")
+            if arr.shape != (1, n_atoms):
+                # try to clean it up
+                if len(arr.shape) == 1 and arr.shape[0] ==  n_atoms:
+                    arr.shape = (1, n_atoms)
+                else:
+                    raise TypeError(f"Invalid input. Requires {n_atoms} "
+                                    "atoms.")
+        except Exception as e:
+            wizard.exception(f"Sorry, I did't understand '{atoms_str}'", e)
+            mdtraj_atom_helper(wizard, '?', n_atoms)
+            arr = None
+            continue
+
+    if arr is not None:
+        atom_names = [str(topology.mdtraj.atom(i)) for i in arr[0]]
+        wizard.say("Using atoms: " + " ".join(atom_names))
+    return arr
+
+def _mdtraj_function_cv(wizard, cv_does_str, cv_user_prompt, func,
+                        kwarg_name, n_atoms):
+    from openpathsampling.experimental.storage.collective_variables import \
+            MDTrajFunctionCV
+    wizard.say("We'll make a CV that measures the distance between two "
+               "atoms.")
+    topology = _get_topology(wizard)
+    indices = _get_atom_indices(wizard, topology, n_atoms=n_atoms)
+    kwargs = {kwarg_name: indices}
+
+    return MDTrajFunctionCV(func, topology, **kwargs)
+
+def distance(wizard):
+    return _mdtraj_function_cv(
+        wizard=wizard,
+        cv_does_str="distance between two atoms",
+        cv_user_prompt="measure the distance between",
+        func=md.compute_distances,
+        kwarg_name='atom_pairs',
+        n_atoms=2
+    )
+
+def angle(wizard):
+    return _mdtraj_function_cv(
+        wizard=wizard,
+        cv_does_str="angle made by three atoms",
+        cv_user_prompt="use to define the angle",
+        func=md.compute_angles,
+        kwarg_name='angle_indices',
+        n_atoms=3
+    )
+
+def dihedral(wizard):
+    return _mdtraj_function_cv(
+        wizard=wizard,
+        cv_does_str="dihedral made by four atoms",
+        cv_user_prompt="use to define the dihedral angle",
+        func=md.compute_dihedrals,
+        kwarg_name='indices',
+        n_atoms=4
+    )
+
+def rmsd(wizard):
+    raise NotImplementedError("RMSD has not yet been implemented")
+
+def coordinate(wizard):
+    atom_index = coord = None
+    while atom_index is None:
+        idx = wizard.ask("For which atom do you want to get the "
+                         "coordinate? (counting from zero)")
+        try:
+            atom_index = int(idx)
+        except Exception as e:
+            wizard.exception("Sorry, I can't make an atom index from "
+                             f"'{idx}'", e)
+
+    while coord is None:
+        xyz = wizard.ask("Which coordinate (x, y, or z) do you want for "
+                         f"atom {atom_index}?")
+        try:
+            coord = {'x': 0, 'y': 1, 'z': 2}[xyz]
+        except KeyError as e:
+            wizard.bad_input("Please select one of 'x', 'y', or 'z'")
+
+SUPPORTED_CVS = {}
+
+if HAS_MDTRAJ:
+    SUPPORTED_CVS.update({
+        'Distance': distance,
+        'Angle': angle,
+        'Dihedral': dihedral,
+        'RMSD': rmsd,
+    })
+
+SUPPORTED_CVS.update({
+    'Coordinate': coordinate,
+    'Python script': ...,
+    _load_label: partial(load_from_ops,
+                         store_name='cvs',
+                         obj_name='CV'),
+})
+
+def cvs(wizard):
+    wizard.say("You'll need to describe your system in terms of "
+               "collective variables (CVs). We'll use these to define "
+               "things like stable states.")
+    cv_names = list(SUPPORTED_CVS.keys())
+    cv = None
+    while cv is None:
+        cv_type = wizard.ask_enumerate("What kind of CV do you want to "
+                                       "define?", options=cv_names)
+        cv = SUPPORTED_CVS[cv_type](wizard)
+    return cv
+
+if __name__ == "__main__":
+    from paths_cli.wizard.wizard import Wizard
+    wiz = Wizard({})
+    cvs(wiz)

--- a/paths_cli/wizard/cvs.py
+++ b/paths_cli/wizard/cvs.py
@@ -78,12 +78,12 @@ def _mdtraj_function_cv(wizard, cv_does_str, cv_user_prompt, func,
     indices = _get_atom_indices(wizard, topology, n_atoms=n_atoms,
                                 cv_user_str=cv_user_prompt)
     kwargs = {kwarg_name: indices}
+    atoms_str = " ".join([str(topology.mdtraj.atom(i)) for i in indices[0]])
 
     summary = ("Here's what we'll create:\n"
                f"  Function: {func.__name__}\n"
-               f"     Atoms: {" ".join([str(topology.mdtraj.atom(i))
-                                        for i in indices[0]])} \n"
-               f"  Topology: {repr(topology.mdtraj))}"
+               f"     Atoms: {atoms_str}\n"
+               f"  Topology: {repr(topology.mdtraj)}")
     wizard.say(summary)
 
     return MDTrajFunctionCV(func, topology, period_min=period_min,

--- a/paths_cli/wizard/cvs.py
+++ b/paths_cli/wizard/cvs.py
@@ -9,7 +9,7 @@ import numpy as np
 
 try:
     import mdtraj as md
-except ImportError:
+except ImportError:  # no-cov
     HAS_MDTRAJ = False
 else:
     HAS_MDTRAJ = True

--- a/paths_cli/wizard/engines.py
+++ b/paths_cli/wizard/engines.py
@@ -1,0 +1,29 @@
+import paths_cli.wizard.openmm as openmm
+from load_from_ops import load_from_ops, LABEL as load_label
+from functools import partial
+
+SUPPORTED_ENGINES = {}
+for module in [openmm]:
+    SUPPORTED_ENGINES.update(module.SUPPORTED)
+
+SUPPORTED_ENGINES[load_label] = partial(load_from_ops,
+                                        store_name='engines',
+                                        obj_name='engine')
+
+def engines(wizard):
+    wizard.say("Let's make an engine. An engine describes how you'll do "
+               "the actual dynamics. Most of the details are given "
+               "in files that depend on the specific type of engine.")
+    engine_names = list(SUPPORTED_ENGINES.keys())
+    eng_name = wizard.ask_enumerate(
+        "What will you use for the underlying engine?",
+        options=engine_names
+    )
+    engine = SUPPORTED_ENGINES[eng_name](wizard)
+    return engine
+
+if __name__ == "__main__":
+    from paths_cli.wizard import wizard
+    wiz = wizard.Wizard({'engines': ('engines', 1, '=')})
+    wiz.run_wizard()
+

--- a/paths_cli/wizard/engines.py
+++ b/paths_cli/wizard/engines.py
@@ -1,5 +1,7 @@
 import paths_cli.wizard.openmm as openmm
-from load_from_ops import load_from_ops, LABEL as load_label
+from paths_cli.wizard.load_from_ops import (
+    load_from_ops, LABEL as load_label
+)
 from functools import partial
 
 SUPPORTED_ENGINES = {}

--- a/paths_cli/wizard/errors.py
+++ b/paths_cli/wizard/errors.py
@@ -7,16 +7,16 @@ class ImpossibleError(Exception):
 class RestartObjectException(BaseException):
     pass
 
-def not_installed(package, obj_type):
-    retry = wizard.ask("Hey, it looks like you don't have {package} "
+def not_installed(wizard, package, obj_type):
+    retry = wizard.ask(f"Hey, it looks like you don't have {package} "
                        "installed. Do you want to try a different "
-                       "{obj_type}, or do you want to quit?",
+                       f"{obj_type}, or do you want to quit?",
                        options=["[R]etry", "[Q]uit"])
     if retry == 'r':
-        return
+        raise RestartObjectException()
     elif retry == 'q':
         exit()
-    else:
+    else:  # no-cov
         raise ImpossibleError()
 
 

--- a/paths_cli/wizard/errors.py
+++ b/paths_cli/wizard/errors.py
@@ -1,0 +1,21 @@
+class ImpossibleError(Exception):
+    def __init__(self, msg=None):
+        if msg is None:
+            msg = "Something went really wrong. You should never see this."
+        super().__init__(msg)
+
+def not_installed(package, obj_type):
+    retry = wizard.ask("Hey, it looks like you don't have {package} "
+                       "installed. Do you want to try a different "
+                       "{obj_type}, or do you want to quit?",
+                       options=["[R]etry", "[Q]uit"])
+    if retry == 'r':
+        return
+    elif retry == 'q':
+        exit()
+    else:
+        raise ImpossibleError()
+
+
+FILE_LOADING_ERROR_MSG = ("Sorry, something went wrong when loading that "
+                          "file.")

--- a/paths_cli/wizard/errors.py
+++ b/paths_cli/wizard/errors.py
@@ -4,6 +4,9 @@ class ImpossibleError(Exception):
             msg = "Something went really wrong. You should never see this."
         super().__init__(msg)
 
+class RestartObjectException(BaseException):
+    pass
+
 def not_installed(package, obj_type):
     retry = wizard.ask("Hey, it looks like you don't have {package} "
                        "installed. Do you want to try a different "

--- a/paths_cli/wizard/joke.py
+++ b/paths_cli/wizard/joke.py
@@ -1,0 +1,54 @@
+import random
+
+from paths_cli.wizard.tools import a_an
+
+_NAMES = ['Fred', 'Winston', 'Agnes', "Millicent", "Ophelia", "Laszlo",
+          "Werner"]
+_THINGS = ['pet spider', 'teddy bear', 'close friend', 'school teacher',
+           'iguana']
+_SPAWN = ['daughter', 'son', 'first-born']
+
+_MISC = [
+    "Named after its father, perhaps?",
+    "Isn't '{name}' also the name of a village in Tuscany?",
+    "Didn't Johnny Cash write a song about {a_an_thing} called '{name}'?",
+    "I think I'm going to start rapping as 'DJ {name}'.",
+]
+
+def _joke1(name, obj_type):
+    return (f"I probably would have named it something like "
+            f"'{random.choice(_NAMES)}'.")
+
+def _joke2(name, obj_type):
+    thing = random.choice(_THINGS)
+    joke = (f"I had {a_an(thing)} {thing} named '{name}' "
+            f"when I was young.")
+    return joke
+
+def _joke3(name, obj_type):
+    return (f"I wanted to name my {random.choice(_SPAWN)} '{name}', but my "
+            f"wife wouldn't let me.")
+
+def _joke4(name, obj_type):
+    a_an_thing = a_an(obj_type) + f" {obj_type}"
+    return random.choice(_MISC).format(name=name, obj_type=obj_type,
+                                       a_an_thing=a_an_thing)
+
+def name_joke(name, obj_type):
+    rnd = random.random()
+    if 0 <= rnd < 0.30:
+        joke = _joke1
+    elif 0.30 <= rnd < 0.70:
+        joke = _joke2
+    elif 0.70 <= rnd < 0.85:
+        joke = _joke4
+    else:
+        joke = _joke3
+    return joke(name, obj_type)
+
+if __name__ == "__main__":
+    for _ in range(5):
+        print()
+        print(name_joke('AD_300K', 'engine'))
+        print()
+        print(name_joke('C_7eq', 'state'))

--- a/paths_cli/wizard/joke.py
+++ b/paths_cli/wizard/joke.py
@@ -11,8 +11,9 @@ _SPAWN = ['daughter', 'son', 'first-born']
 _MISC = [
     "Named after its father, perhaps?",
     "Isn't '{name}' also the name of a village in Tuscany?",
-    "Didn't Johnny Cash write a song about {a_an_thing} called '{name}'?",
+    "Didn't Johnny Cash write a song about {a_an_thing} named '{name}'?",
     "I think I'm going to start rapping as 'DJ {name}'.",
+    "It would also be a good name for a death metal band.",
 ]
 
 def _joke1(name, obj_type):
@@ -38,12 +39,12 @@ def name_joke(name, obj_type):
     rnd = random.random()
     if 0 <= rnd < 0.30:
         joke = _joke1
-    elif 0.30 <= rnd < 0.70:
+    elif 0.30 <= rnd < 0.60:
         joke = _joke2
-    elif 0.70 <= rnd < 0.85:
-        joke = _joke4
-    else:
+    elif 0.60 <= rnd < 0.75:
         joke = _joke3
+    else:
+        joke = _joke4
     return joke(name, obj_type)
 
 if __name__ == "__main__":

--- a/paths_cli/wizard/joke.py
+++ b/paths_cli/wizard/joke.py
@@ -37,11 +37,11 @@ def _joke4(name, obj_type):
 
 def name_joke(name, obj_type):
     rnd = random.random()
-    if 0 <= rnd < 0.30:
+    if rnd < 0.25:
         joke = _joke1
-    elif 0.30 <= rnd < 0.60:
+    elif rnd < 0.50:
         joke = _joke2
-    elif 0.60 <= rnd < 0.75:
+    elif rnd < 0.65:
         joke = _joke3
     else:
         joke = _joke4

--- a/paths_cli/wizard/joke.py
+++ b/paths_cli/wizard/joke.py
@@ -36,15 +36,9 @@ def _joke4(name, obj_type):  # no-cov
                                        a_an_thing=a_an_thing)
 
 def name_joke(name, obj_type):  # no-cov
-    rnd = random.random()
-    if rnd < 0.25:
-        joke = _joke1
-    elif rnd < 0.50:
-        joke = _joke2
-    elif rnd < 0.65:
-        joke = _joke3
-    else:
-        joke = _joke4
+    jokes = [_joke1, _joke2, _joke3, _joke4]
+    weights = [5, 5, 3, 7]
+    joke = random.choices(jokes, weights=weights)[0]
     return joke(name, obj_type)
 
 if __name__ == "__main__":

--- a/paths_cli/wizard/joke.py
+++ b/paths_cli/wizard/joke.py
@@ -16,26 +16,26 @@ _MISC = [
     "It would also be a good name for a death metal band.",
 ]
 
-def _joke1(name, obj_type):
+def _joke1(name, obj_type):  # no-cov
     return (f"I probably would have named it something like "
             f"'{random.choice(_NAMES)}'.")
 
-def _joke2(name, obj_type):
+def _joke2(name, obj_type):  # no-cov
     thing = random.choice(_THINGS)
     joke = (f"I had {a_an(thing)} {thing} named '{name}' "
             f"when I was young.")
     return joke
 
-def _joke3(name, obj_type):
+def _joke3(name, obj_type):  # no-cov
     return (f"I wanted to name my {random.choice(_SPAWN)} '{name}', but my "
             f"wife wouldn't let me.")
 
-def _joke4(name, obj_type):
+def _joke4(name, obj_type):  # no-cov
     a_an_thing = a_an(obj_type) + f" {obj_type}"
     return random.choice(_MISC).format(name=name, obj_type=obj_type,
                                        a_an_thing=a_an_thing)
 
-def name_joke(name, obj_type):
+def name_joke(name, obj_type):  # no-cov
     rnd = random.random()
     if rnd < 0.25:
         joke = _joke1

--- a/paths_cli/wizard/load_from_ops.py
+++ b/paths_cli/wizard/load_from_ops.py
@@ -9,7 +9,7 @@ def named_objs_helper(storage, store_name):
         store = getattr(storage, store_name)
         names = [obj for obj in store if obj.is_named]
         outstr = "\n".join(['* ' + obj.name for obj in names])
-        wizard.say("Here's what I found:\n\n" + outstr)
+        wizard.say(f"Here's what I found:\n\n{outstr})
 
     return list_items
 

--- a/paths_cli/wizard/load_from_ops.py
+++ b/paths_cli/wizard/load_from_ops.py
@@ -1,6 +1,8 @@
-LABEL = "Load existing from OPS file"
 from paths_cli.parameters import INPUT_FILE
 from paths_cli.wizard.core import get_object
+
+from paths_cli.wizard.errors import FILE_LOADING_ERROR_MSG
+LABEL = "Load existing from OPS file"
 
 def named_objs_helper(storage, store_name):
     def list_items(wizard, user_input):

--- a/paths_cli/wizard/load_from_ops.py
+++ b/paths_cli/wizard/load_from_ops.py
@@ -1,5 +1,6 @@
 LABEL = "Load existing from OPS file"
 from paths_cli.parameters import INPUT_FILE
+from paths_cli.wizard.core import get_object
 
 def named_objs_helper(storage, store_name):
     def list_items(wizard, user_input):
@@ -10,28 +11,35 @@ def named_objs_helper(storage, store_name):
 
     return list_items
 
+@get_object
+def _get_ops_storage(wizard):
+    filename = wizard.ask("What file can it be found in?",
+                          default='filename')
+    try:
+        storage = INPUT_FILE.get(filename)
+    except Exception as e:
+        wizard.exception(FILE_LOADING_ERROR_MSG, e)
+        return
+
+    return storage
+
+@get_object
+def _get_ops_object(wizard, storage, store_name, obj_name):
+    name = wizard.ask(f"What's the name of the {obj_name} you want to "
+                      "load? (Type '?' to get a list of them)",
+                      helper=named_objs_helper(storage, store_name))
+    if name:
+        try:
+            obj = getattr(storage, store_name)[name]
+        except Exception as e:
+            wizard.exception("Something went wrong when loading "
+                   f"{name}. Maybe check the spelling?", e)
+            return
+        else:
+            return obj
 
 def load_from_ops(wizard, store_name, obj_name):
     wizard.say("Okay, we'll load it from an OPS file.")
-    storage = None
-    while storage is None:
-        filename = wizard.ask("What file can it be found in?",
-                              default='filename')
-        try:
-            storage = INPUT_FILE.get(filename)
-        except Exception as e:
-            wizard.exception(FILE_LOADING_ERROR_MSG, e)
-            # TODO: error handling
-
-    obj = None
-    while obj is None:
-        name = wizard.ask(f"What's the name of the {obj_name} you want to "
-                          "load? (Type '?' to get a list of them)",
-                          helper=named_objs_helper(storage, store_name))
-        if name:
-            try:
-                obj = getattr(storage, store_name)[name]
-            except Exception as e:
-                wizard.exception("Something went wrong when loading "
-                                 f"{name}. Maybe check the spelling?", e)
+    storage = _get_ops_storage(wizard)
+    obj = _get_ops_object(wizard, storage, store_name, obj_name)
     return obj

--- a/paths_cli/wizard/load_from_ops.py
+++ b/paths_cli/wizard/load_from_ops.py
@@ -9,7 +9,7 @@ def named_objs_helper(storage, store_name):
         store = getattr(storage, store_name)
         names = [obj for obj in store if obj.is_named]
         outstr = "\n".join(['* ' + obj.name for obj in names])
-        wizard.say(f"Here's what I found:\n\n{outstr})
+        wizard.say(f"Here's what I found:\n\n{outstr}")
 
     return list_items
 

--- a/paths_cli/wizard/load_from_ops.py
+++ b/paths_cli/wizard/load_from_ops.py
@@ -1,0 +1,37 @@
+LABEL = "Load existing from OPS file"
+from paths_cli.parameters import INPUT_FILE
+
+def named_objs_helper(storage, store_name):
+    def list_items(wizard, user_input):
+        store = getattr(storage, store_name)
+        names = [obj for obj in store if obj.is_named]
+        outstr = "\n".join(['* ' + obj.name for obj in names])
+        wizard.say("Here's what I found:\n\n" + outstr)
+
+    return list_items
+
+
+def load_from_ops(wizard, store_name, obj_name):
+    wizard.say("Okay, we'll load it from an OPS file.")
+    storage = None
+    while storage is None:
+        filename = wizard.ask("What file can it be found in?",
+                              default='filename')
+        try:
+            storage = INPUT_FILE.get(filename)
+        except Exception as e:
+            wizard.exception(FILE_LOADING_ERROR_MSG, e)
+            # TODO: error handling
+
+    obj = None
+    while obj is None:
+        name = wizard.ask(f"What's the name of the {obj_name} you want to "
+                          "load? (Type '?' to get a list of them)",
+                          helper=named_objs_helper(storage, store_name))
+        if name:
+            try:
+                obj = getattr(storage, store_name)[name]
+            except Exception as e:
+                wizard.exception("Something went wrong when loading "
+                                 f"{name}. Maybe check the spelling?", e)
+    return obj

--- a/paths_cli/wizard/openmm.py
+++ b/paths_cli/wizard/openmm.py
@@ -8,7 +8,7 @@ else:
     HAS_OPENMM = True
 
 
-def _openmm_serialization_helper(wizard, user_input):
+def _openmm_serialization_helper(wizard, user_input):  # no-cov
     wizard.say("You can write OpenMM objects like systems and integrators "
                "to XML files using the XMLSerializer class. Learn more "
                "here: \n"

--- a/paths_cli/wizard/openmm.py
+++ b/paths_cli/wizard/openmm.py
@@ -8,13 +8,15 @@ except ImportError:
 else:
     HAS_OPENMM = True
 
+OPENMM_SERIALIZATION_URL=(
+    "http://docs.openmm.org/latest/api-python/generated/"
+    "simtk.openmm.openmm.XmlSerializer.html"
+)
 
 def _openmm_serialization_helper(wizard, user_input):  # no-cov
     wizard.say("You can write OpenMM objects like systems and integrators "
                "to XML files using the XMLSerializer class. Learn more "
-               "here: \n"
-               "http://docs.openmm.org/latest/api-python/generated/"
-               "simtk.openmm.openmm.XmlSerializer.html")
+               f"here: \n{OPENMM_SERIALIZATION_URL}")
 
 
 @get_object

--- a/paths_cli/wizard/openmm.py
+++ b/paths_cli/wizard/openmm.py
@@ -1,0 +1,88 @@
+from paths_cli.wizard.errors import FILE_LOADING_ERROR_MSG, not_installed
+from paths_cli.wizard.tools import get_int_value
+try:
+    from simtk import openmm as mm
+    import mdtraj as md
+except ImportError:
+    HAS_OPENMM = False
+else:
+    HAS_OPENMM = True
+
+
+def _openmm_serialization_helper(wizard, user_input):
+    wizard.say("You can write OpenMM objects like systems and integrators "
+               "to XML files using the XMLSerializer class. Learn more "
+               "here: \n"
+               "http://docs.openmm.org/latest/api-python/generated/"
+               "simtk.openmm.openmm.XmlSerializer.html")
+
+
+def _load_openmm_xml(wizard, obj_type):
+    xml = wizard.ask(
+        f"Where is the XML file for your OpenMM {obj_type}?",
+        helper=_openmm_serialization_helper
+    )
+    try:
+        with open(xml, 'r') as xml_f:
+            data = xml_f.read()
+        obj = mm.XmlSerializer.deserialize(data)
+    except Exception as e:
+        wizard.exception(FILE_LOADING_ERROR_MSG, e)
+    else:
+        return obj
+
+def _load_topology(wizard):
+    import openpathsampling as paths
+    topology = None
+    while topology is None:
+        filename = wizard.ask("Where is a PDB file describing your system?")
+        try:
+            snap = paths.engines.openmm.snapshot_from_pdb(filename)
+        except Exception as e:
+            wizard.exception(FILE_LOADING_ERROR_MSG, e)
+            continue
+
+        topology = snap.topology
+
+    return topology
+
+def openmm(wizard):
+    import openpathsampling as paths
+    # quick exit if not installed; but should be impossible to get here
+    if not HAS_OPENMM:
+        not_installed("OpenMM", "engine")
+        return
+
+    wizard.say("Great! OpenMM gives you a lot of flexibility. "
+               "To use OpenMM in OPS, you need to provide XML versions of "
+               "your system, integrator, and some file containing "
+               "topology information.")
+    system = integrator = topology = None
+    while system is None:
+        system = _load_openmm_xml(wizard, 'system')
+
+    while integrator is None:
+        integrator = _load_openmm_xml(wizard, 'integrator')
+
+    while topology is None:
+        topology = _load_topology(wizard)
+
+    n_frames_max = n_steps_per_frame = None
+
+    n_steps_per_frame = get_int_value(wizard,
+                                      "How many MD steps per saved frame?")
+    n_frames_max = get_int_value(wizard, ("How many frames before aborting "
+                                          "a trajectory?"))
+    # TODO: assemble the OpenMM simulation
+    engine = paths.engines.openmm.Engine(
+        topology=topology,
+        system=system,
+        integrator=integrator,
+        options={
+            'n_steps_per_frame': n_steps_per_frame,
+            'n_frames_max': n_frames_max,
+        }
+    )
+    return engine
+
+SUPPORTED = {"OpenMM": openmm} if HAS_OPENMM else {}

--- a/paths_cli/wizard/openmm.py
+++ b/paths_cli/wizard/openmm.py
@@ -1,5 +1,4 @@
 from paths_cli.wizard.errors import FILE_LOADING_ERROR_MSG, not_installed
-from paths_cli.wizard.tools import get_int_value
 try:
     from simtk import openmm as mm
     import mdtraj as md
@@ -69,10 +68,12 @@ def openmm(wizard):
 
     n_frames_max = n_steps_per_frame = None
 
-    n_steps_per_frame = get_int_value(wizard,
-                                      "How many MD steps per saved frame?")
-    n_frames_max = get_int_value(wizard, ("How many frames before aborting "
-                                          "a trajectory?"))
+    n_steps_per_frame = wizard.ask_custom_eval(
+        "How many MD steps per saved frame?", type_=int
+    )
+    n_frames_max = wizard.ask_custom_eval(
+        "How many frames before aborting a trajectory?", type_=int
+    )
     # TODO: assemble the OpenMM simulation
     engine = paths.engines.openmm.Engine(
         topology=topology,

--- a/paths_cli/wizard/openmm.py
+++ b/paths_cli/wizard/openmm.py
@@ -47,7 +47,7 @@ def _load_topology(wizard):
 def openmm(wizard):
     import openpathsampling as paths
     # quick exit if not installed; but should be impossible to get here
-    if not HAS_OPENMM:
+    if not HAS_OPENMM:  # no-cov
         not_installed("OpenMM", "engine")
         return
 

--- a/paths_cli/wizard/shooting.py
+++ b/paths_cli/wizard/shooting.py
@@ -49,11 +49,9 @@ def _get_selector(wizard, selectors):
     if selectors is None:
         selectors = SHOOTING_SELECTORS
     selector = None
-    while selector is None:
-        sel = wizard.ask_enumerate("How do you want to select shooting "
-                                   "points?", options=list(selectors.keys()))
-        selector = selectors[sel](wizard)
-
+    sel = wizard.ask_enumerate("How do you want to select shooting "
+                               "points?", options=list(selectors.keys()))
+    selector = selectors[sel](wizard)
     return selector
 
 def one_way_shooting(wizard, selectors=None, engine=None):
@@ -112,12 +110,11 @@ def shooting(wizard, shooting_types=None, engine=None):
     if len(shooting_types) == 1:
         shooting_type = list(shooting_types.values())[0]
     else:
-        while shooting_type is None:
-            type_name = wizard.ask_enumerate(
-                "Select the type of shooting move.",
-                options=list(shooting_types.keys())
-            )
-            shooting_type = shooting_types[type_name]
+        type_name = wizard.ask_enumerate(
+            "Select the type of shooting move.",
+            options=list(shooting_types.keys())
+        )
+        shooting_type = shooting_types[type_name]
 
     shooting_strategy = shooting_type(wizard)
     return shooting_strategy

--- a/paths_cli/wizard/shooting.py
+++ b/paths_cli/wizard/shooting.py
@@ -12,8 +12,10 @@ def uniform_selector(wizard):
 
 def gaussian_selector(wizard):
     import openpathsampling as paths
-    cv = wizard.ask_enumerate("Which CV do you want the Gaussian to be "
-                              "based on?", options=wizard.cvs.keys())
+    cv_name = wizard.ask_enumerate("Which CV do you want the Gaussian to "
+                                   "be based on?",
+                                   options=wizard.cvs.keys())
+    cv = wizard.cvs[cv_name]
     l_0 = wizard.ask_custom_eval(f"At what value of {cv.name} should the "
                                  "Gaussian be centered?")
     std = wizard.ask_custom_eval("What should be the standard deviation of "
@@ -45,7 +47,7 @@ SHOOTING_SELECTORS = {
 }
 
 
-def _get_selector(wizard, selectors):
+def _get_selector(wizard, selectors=None):
     if selectors is None:
         selectors = SHOOTING_SELECTORS
     selector = None
@@ -61,7 +63,8 @@ def one_way_shooting(wizard, selectors=None, engine=None):
                                     engines)
 
     selector = _get_selector(wizard, selectors)
-    strat = strategies.OneWayShootingStrategy(selector=selector)
+    strat = strategies.OneWayShootingStrategy(selector=selector,
+                                              engine=engine)
     return strat
 
 # def two_way_shooting(wizard, selectors=None, modifiers=None):
@@ -78,8 +81,9 @@ def spring_shooting(wizard, engine=None):
     )
     k_spring = wizard.ask_custom_eval("What is the spring constant k?",
                                       type_=float)
-    strat = strategies.SpringShootingStrategy(delta_max=delta_max,
-                                              k_spring=k_spring)
+    strat = strategies.SpringShootingMoveScheme(
+        delta_max=delta_max, k_spring=k_spring, engine=engine
+    )
     return strat
 
 

--- a/paths_cli/wizard/shooting.py
+++ b/paths_cli/wizard/shooting.py
@@ -22,22 +22,22 @@ def gaussian_selector(wizard):
     selector = paths.GaussianBiasSelector(cv, alpha=alpha, l_0=l_0)
     return selector
 
-def random_velocities(wizard):
-    pass
+# def random_velocities(wizard):
+    # pass
 
-def gaussian_momentum_shift(wizard):
-    pass
+# def gaussian_momentum_shift(wizard):
+    # pass
 
-def get_allowed_modifiers(engine):
-    allowed = []
-    randomize_attribs = ['randomize_velocities', 'apply_constraints']
-    if any(hasattr(engine, attr) for attr in randomize_attribs):
-        allowed.append('random_velocities')
+# def get_allowed_modifiers(engine):
+    # allowed = []
+    # randomize_attribs = ['randomize_velocities', 'apply_constraints']
+    # if any(hasattr(engine, attr) for attr in randomize_attribs):
+        # allowed.append('random_velocities')
 
-    if not engine.has_constraints():
-        allowed.append('velocity_changers')
+    # if not engine.has_constraints():
+        # allowed.append('velocity_changers')
 
-    return allowed
+    # return allowed
 
 SHOOTING_SELECTORS = {
     'Uniform random': uniform_selector,
@@ -64,8 +64,8 @@ def one_way_shooting(wizard, selectors=None, engine=None):
     strat = strategies.OneWayShootingStrategy(selector=selector)
     return strat
 
-def two_way_shooting(wizard, selectors=None, modifiers=None):
-    pass
+# def two_way_shooting(wizard, selectors=None, modifiers=None):
+    # pass
 
 def spring_shooting(wizard, engine=None):
     from openpathsampling import strategies

--- a/paths_cli/wizard/shooting.py
+++ b/paths_cli/wizard/shooting.py
@@ -3,7 +3,7 @@ from functools import partial
 from paths_cli.wizard.core import get_missing_object
 from paths_cli.wizard.engines import engines
 from paths_cli.wizard.cvs import cvs
-from paths_cli.parsing.core import custom_eval
+from paths_cli.parsing.tools import custom_eval
 
 import numpy as np
 

--- a/paths_cli/wizard/shooting.py
+++ b/paths_cli/wizard/shooting.py
@@ -1,0 +1,124 @@
+from paths_cli.wizard.core import get_missing_object
+from paths_cli.wizard.engines import engines
+from paths_cli.wizard.cvs import cvs
+from paths_cli.parsing.core import custom_eval
+
+import numpy as np
+
+
+def uniform_selector(wizard):
+    import openpathsampling as paths
+    return paths.UniformSelector()
+
+def gaussian_selector(wizard):
+    import openpathsampling as paths
+    cv = wizard.ask_enumerate("Which CV do you want the Gaussian to be "
+                              "based on?", options=wizard.cvs.keys())
+    l_0 = wizard.ask_custom_eval(f"At what value of {cv.name} should the "
+                                 "Gaussian be centered?")
+    std = wizard.ask_custom_eval("What should be the standard deviation of "
+                                 "the Gaussian?")
+    alpha = 0.5 / (std**2)
+    selector = paths.GaussianBiasSelector(cv, alpha=alpha, l_0=l_0)
+    return selector
+
+def random_velocities(wizard):
+    pass
+
+def gaussian_momentum_shift(wizard):
+    pass
+
+def get_allowed_modifiers(engine):
+    allowed = []
+    randomize_attribs = ['randomize_velocities', 'apply_constraints']
+    if any(hasattr(engine, attr) for attr in randomize_attribs):
+        allowed.append('random_velocities')
+
+    if not engine.has_constraints():
+        allowed.append('velocity_changers')
+
+    return allowed
+
+SHOOTING_SELECTORS = {
+    'Uniform random': uniform_selector,
+    'Gaussian bias': gaussian_selector,
+}
+
+
+def _get_selector(wizard, selectors):
+    if selectors is None:
+        selectors = SHOOTING_SELECTORS
+    selector = None
+    while selector is None:
+        sel = wizard.ask_enumerate("How do you want to select shooting "
+                                   "points?", options=list(selectors.keys()))
+        selector = selectors[sel](wizard)
+
+    return selector
+
+def one_way_shooting(wizard, selectors=None, engine=None):
+    from openpathsampling import strategies
+    if engine is None:
+        engine = get_missing_object(wizard, wizard.engines, 'engine',
+                                    engines)
+
+    selector = _get_selector(wizard, selectors)
+    strat = strategies.OneWayShootingStrategy(selector=selector)
+    return strat
+
+def two_way_shooting(wizard, selectors=None, modifiers=None):
+    pass
+
+def spring_shooting(wizard, engine=None):
+    from openpathsampling import strategies
+    if engine is None:
+        engine = get_missing_object(wizard, wizard.engines, 'engine',
+                                    engines)
+
+    delta_max = wizard.ask_custom_eval(
+        "What is the maximum shift (delta_max) in frames?", type_=int
+    )
+    k_spring = wizard.ask_custom_eval("What is the spring constant k?",
+                                      type_=float)
+    strat = strategies.SpringShootingStrategy(delta_max=delta_max,
+                                              k_spring=k_spring)
+    return strat
+
+
+SHOOTING_TYPES = {
+    'One-way (stochastic) shooting': one_way_shooting,
+    # 'Two-way shooting': two_way_shooting,
+    'Spring shooting': spring_shooting,
+}
+
+
+def shooting(wizard, shooting_types=None, engine=None):
+    if shooting_types is None:
+        shooting_types = SHOOTING_TYPES
+
+    if engine is None:
+        engine = get_missing_object(wizard, wizard.engines, 'engine',
+                                    engines)
+
+    # allowed_modifiers = get_allowed_modifiers(engine)
+    # TWO_WAY = 'Two-way shooting'
+    # if len(allowed_modifiers) == 0 and TWO_WAY in shooting_types:
+        # del shooting_types[TWO_WAY]
+    # else:
+        # shooting_types[TWO_WAY] = partial(two_way_shooting,
+                                          # allowed_modifiers=allowed_modifiers)
+
+    shooting_type = None
+    if len(shooting_types) == 1:
+        shooting_type = list(shooting_types.values())[0]
+    else:
+        while shooting_type is None:
+            type_name = wizard.ask_enumerate(
+                "Select the type of shooting move.",
+                options=list(shooting_types.keys())
+            )
+            shooting_type = shooting_types[type_name]
+
+    shooting_strategy = shooting_type(wizard)
+    return shooting_strategy
+

--- a/paths_cli/wizard/shooting.py
+++ b/paths_cli/wizard/shooting.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from paths_cli.wizard.core import get_missing_object
 from paths_cli.wizard.engines import engines
 from paths_cli.wizard.cvs import cvs
@@ -71,7 +73,7 @@ def one_way_shooting(wizard, selectors=None, engine=None):
     # pass
 
 def spring_shooting(wizard, engine=None):
-    from openpathsampling import strategies
+    import openpathsampling as paths
     if engine is None:
         engine = get_missing_object(wizard, wizard.engines, 'engine',
                                     engines)
@@ -81,9 +83,10 @@ def spring_shooting(wizard, engine=None):
     )
     k_spring = wizard.ask_custom_eval("What is the spring constant k?",
                                       type_=float)
-    strat = strategies.SpringShootingMoveScheme(
-        delta_max=delta_max, k_spring=k_spring, engine=engine
-    )
+    strat = partial(paths.SpringShootingMoveScheme,
+                    delta_max=delta_max,
+                    k_spring=k_spring,
+                    engine=engine)
     return strat
 
 

--- a/paths_cli/wizard/steps.py
+++ b/paths_cli/wizard/steps.py
@@ -1,0 +1,32 @@
+from collections import namedtuple
+from functools import partial
+
+from paths_cli.wizard.cvs import cvs
+from paths_cli.wizard.engines import engines
+from paths_cli.wizard.volumes import volumes
+from paths_cli.wizard.tps import (
+    flex_length_tps_network, fixed_length_tps_network, tps_scheme
+)
+
+WizardStep = namedtuple('WizardStep', ['func', 'display_name', 'store_name',
+                                       'minimum', 'maximum'])
+
+SINGLE_ENGINE_STEP = WizardStep(func=engines,
+                                display_name="engine",
+                                store_name="engines",
+                                minimum=1,
+                                maximum=1)
+
+CVS_STEP = WizardStep(func=cvs,
+                      display_name="CV",
+                      store_name='cvs',
+                      minimum=1,
+                      maximum=float('inf'))
+
+MULTIPLE_STATES_STEP = WizardStep(func=partial(volumes, as_state=True),
+                                  display_name="state",
+                                  store_name="states",
+                                  minimum=2,
+                                  maximum=float('inf'))
+
+

--- a/paths_cli/wizard/steps.py
+++ b/paths_cli/wizard/steps.py
@@ -4,9 +4,7 @@ from functools import partial
 from paths_cli.wizard.cvs import cvs
 from paths_cli.wizard.engines import engines
 from paths_cli.wizard.volumes import volumes
-from paths_cli.wizard.tps import (
-    flex_length_tps_network, fixed_length_tps_network, tps_scheme
-)
+from paths_cli.wizard.tps import tps_scheme
 
 WizardStep = namedtuple('WizardStep', ['func', 'display_name', 'store_name',
                                        'minimum', 'maximum'])

--- a/paths_cli/wizard/tools.py
+++ b/paths_cli/wizard/tools.py
@@ -1,0 +1,17 @@
+
+def a_an(obj):
+    return "an" if obj[0] in "aeiou" else "a"
+
+def yes_no(char):
+    return {'y': True, 'n': False}[char]
+
+def get_int_value(wizard, question, default=None, helper=None):
+    as_int = None
+    while as_int is None:
+        evald = wizard.ask_custom_eval(question, default=default,
+                                       helper=helper)
+        try:
+            as_int = int(evald)
+        except Exception as e:
+            wizard.exception("Sorry, I didn't understand that.", e)
+    return as_int

--- a/paths_cli/wizard/tools.py
+++ b/paths_cli/wizard/tools.py
@@ -1,17 +1,5 @@
-
 def a_an(obj):
-    return "an" if obj[0] in "aeiou" else "a"
+    return "an" if obj[0].lower() in "aeiou" else "a"
 
 def yes_no(char):
     return {'y': True, 'n': False}[char]
-
-def get_int_value(wizard, question, default=None, helper=None):
-    as_int = None
-    while as_int is None:
-        evald = wizard.ask_custom_eval(question, default=default,
-                                       helper=helper)
-        try:
-            as_int = int(evald)
-        except Exception as e:
-            wizard.exception("Sorry, I didn't understand that.", e)
-    return as_int

--- a/paths_cli/wizard/tools.py
+++ b/paths_cli/wizard/tools.py
@@ -2,4 +2,4 @@ def a_an(obj):
     return "an" if obj[0].lower() in "aeiou" else "a"
 
 def yes_no(char):
-    return {'y': True, 'n': False}[char]
+    return {'yes': True, 'no': False, 'y': True, 'n': False}[char.lower()]

--- a/paths_cli/wizard/tps.py
+++ b/paths_cli/wizard/tps.py
@@ -1,0 +1,138 @@
+from paths_cli.wizard.tools import a_an
+from paths_cli.wizard.core import get_missing_object
+from paths_cli.wizard.shooting import (
+    shooting,
+    # ALGORITHMS
+    one_way_shooting,
+    two_way_shooting,
+    spring_shooting,
+    # SELECTORS
+    uniform_selector,
+    gaussian_selector,
+    # MODIFIERS
+    random_velocities,
+    # all_atom_delta_v,
+    # single_atom_delta_v,
+)
+from functools import partial
+
+def _select_states(wizard, state_type):
+    states = []
+    do_another = True
+    while do_another:
+        options = [name for name in wizard.states
+                   if name not in states]
+        done = f"No more {state_type} states to select"
+        if len(states) >= 1:
+            options.append(done)
+
+        state = wizard.ask_enumerate(
+            f"Pick a state to use for as {a_an(state_type)} {state_type} "
+            "state", options=options
+        )
+        if state == done:
+            do_another = False
+        else:
+            states.append(state)
+
+    state_objs = [wizard.states[state] for state in states]
+    return state_objs
+
+def _get_pathlength(wizard):
+    pathlength = None
+    while pathlength is None:
+        len_str = wizard.ask("How long (in frames) do you want yout "
+                             "trajectories to be?")
+        try:
+            pathlength = int(len_str)
+        except Exceptions as e:
+            wizard.exception(f"Sorry, I couldn't make '{len_str}' into "
+                             "an integer.", e)
+    return pathlength
+
+def flex_length_tps_network(wizard):
+    import openpathsampling as paths
+    initial_states = _select_states(wizard, 'initial')
+    final_states = _select_states(wizard, 'final')
+    network = paths.TPSNetwork(initial_states, final_states)
+    return network
+
+def fixed_length_tps_network(wizard):
+    pathlength = _get_pathlength(wizard)
+    initial_states = _select_states(wizard, 'initial')
+    final_states = _select_states(wizard, 'final')
+    network = paths.FixedLengthTPSNetwork(initial_states, final_states,
+                                          length=pathlength)
+    return network
+
+def tps_network(wizard):
+    import openpathsampling as paths
+    FIXED = "Fixed length TPS"
+    FLEX = "Flexible length TPS"
+    tps_types = {
+        FLEX: paths.TPSNetwork,
+        FIXED: paths.FixedLengthTPSNetwork,
+    }
+    network_type = None
+    while network_type is None:
+        network_type = wizard.ask_enumerate(
+            "Do you want to do flexible path length TPS (recommended) "
+            "or fixed path length TPS?", options=list(tps_types.keys())
+        )
+        network_class = tps_types[network_type]
+
+    if network_type == FIXED:
+        pathlength = _get_pathlength(wizard)
+        network_class = partial(network_class, length=pathlength)
+
+    initial_states = _select_states(wizard, 'initial')
+    final_states = _select_states(wizard, 'final')
+
+    # TODO: summary
+
+    obj = network_class(initial_states, final_states)
+    return obj
+
+def _get_network(wizard):
+    if len(wizard.networks) == 0:
+        network = tps_network(wizard)
+    elif len(wizard.networks) == 1:
+        network = list(wizard.networks.values())[0]
+    else:
+        networks = list(wizard.networks.keys())
+        sel = wizard.ask_enumerate("Which network would you like to use?",
+                                   options=networks)
+        network = wizard.networks[network]
+    return network
+
+def tps_scheme(wizard, network=None):
+    import openpathsampling as paths
+    from openpathsampling import strategies
+    if network is None:
+        network = get_missing_object(wizard, wizard.networks, 'network',
+                                     tps_network)
+
+    shooting_strategy = shooting(wizard)
+    # TODO: add an option for shifting maybe?
+    global_strategy = strategies.OrganizeByMoveGroupStrategy()
+    scheme = paths.MoveScheme(network)
+    scheme.append(shooting_strategy)
+    scheme.append(global_strategy)
+    return scheme
+
+def tps_finalize(wizard):
+    pass
+
+def tps_setup(wizard):
+    network = tps_network(wizard)
+    scheme = tps_scheme(wizard, network)
+    # name it
+    # provide final info on how to use it
+    return scheme
+
+
+if __name__ == "__main__":
+    from paths_cli.wizard.wizard import Wizard
+    wiz = Wizard({'tps_network': ('networks', 1, '='),
+                  'tps_scheme': ('schemes', 1, '='),
+                  'tps_finalize': (None, None, None)})

--- a/paths_cli/wizard/tps.py
+++ b/paths_cli/wizard/tps.py
@@ -1,7 +1,12 @@
 from paths_cli.wizard.tools import a_an
 from paths_cli.wizard.core import get_missing_object
 from paths_cli.wizard.shooting import shooting
+from paths_cli.wizard.volumes import volumes
+
 from functools import partial
+
+def tps_network(wizard):
+    raise NotImplementedError("Still need to add other network choic")
 
 
 def tps_scheme(wizard, network=None):
@@ -11,9 +16,9 @@ def tps_scheme(wizard, network=None):
         network = get_missing_object(wizard, wizard.networks, 'network',
                                      tps_network)
 
-    shooting_strategy = shooting(wizard, network=network)
+    shooting_strategy = shooting(wizard)
 
-    if not isinstance(shooting_strategy, paths.MoveStrategy):
+    if not isinstance(shooting_strategy, strategies.MoveStrategy):
         # this means we got a fixed scheme and can't do strategies
         return shooting_strategy(network=network)
 

--- a/paths_cli/wizard/tps.py
+++ b/paths_cli/wizard/tps.py
@@ -3,6 +3,7 @@ from paths_cli.wizard.core import get_missing_object
 from paths_cli.wizard.shooting import shooting
 from functools import partial
 
+
 def tps_scheme(wizard, network=None):
     import openpathsampling as paths
     from openpathsampling import strategies
@@ -10,7 +11,12 @@ def tps_scheme(wizard, network=None):
         network = get_missing_object(wizard, wizard.networks, 'network',
                                      tps_network)
 
-    shooting_strategy = shooting(wizard)
+    shooting_strategy = shooting(wizard, network)
+
+    if isinstance(shooting_strategy, paths.MoveScheme):
+        # this means we got a fixed scheme and can't do strategies
+        return shooting_strategy
+
     # TODO: add an option for shifting maybe?
     global_strategy = strategies.OrganizeByMoveGroupStrategy()
     scheme = paths.MoveScheme(network)

--- a/paths_cli/wizard/tps.py
+++ b/paths_cli/wizard/tps.py
@@ -1,99 +1,7 @@
 from paths_cli.wizard.tools import a_an
 from paths_cli.wizard.core import get_missing_object
-from paths_cli.wizard.shooting import (
-    shooting,
-    # ALGORITHMS
-    one_way_shooting,
-    two_way_shooting,
-    spring_shooting,
-    # SELECTORS
-    uniform_selector,
-    gaussian_selector,
-    # MODIFIERS
-    random_velocities,
-    # all_atom_delta_v,
-    # single_atom_delta_v,
-)
+from paths_cli.wizard.shooting import shooting
 from functools import partial
-
-def _select_states(wizard, state_type):
-    # TODO: change this significantly ... I dislike in usage
-    states = []
-    do_another = True
-    while do_another:
-        options = [name for name in wizard.states
-                   if name not in states]
-        done = f"No more {state_type} states to select"
-        if len(states) >= 1:
-            options.append(done)
-
-        state = wizard.ask_enumerate(
-            f"Pick a state to use for as {a_an(state_type)} {state_type} "
-            "state", options=options
-        )
-        if state == done:
-            do_another = False
-        else:
-            states.append(state)
-
-    state_objs = [wizard.states[state] for state in states]
-    return state_objs
-
-def _get_pathlength(wizard):
-    # redo as get_custom_eval with int type
-    pathlength = None
-    while pathlength is None:
-        len_str = wizard.ask("How long (in frames) do you want yout "
-                             "trajectories to be?")
-        try:
-            pathlength = int(len_str)
-        except Exceptions as e:
-            wizard.exception(f"Sorry, I couldn't make '{len_str}' into "
-                             "an integer.", e)
-    return pathlength
-
-def flex_length_tps_network(wizard):
-    import openpathsampling as paths
-    initial_states = _select_states(wizard, 'initial')
-    final_states = _select_states(wizard, 'final')
-    network = paths.TPSNetwork(initial_states, final_states)
-    return network
-
-def fixed_length_tps_network(wizard):
-    import openpathsampling as paths
-    pathlength = _get_pathlength(wizard)
-    initial_states = _select_states(wizard, 'initial')
-    final_states = _select_states(wizard, 'final')
-    network = paths.FixedLengthTPSNetwork(initial_states, final_states,
-                                          length=pathlength)
-    return network
-
-def tps_network(wizard):
-    import openpathsampling as paths
-    FIXED = "Fixed length TPS"
-    FLEX = "Flexible length TPS"
-    tps_types = {
-        FLEX: paths.TPSNetwork,
-        FIXED: paths.FixedLengthTPSNetwork,
-    }
-    network_type = None
-    network_type = wizard.ask_enumerate(
-        "Do you want to do flexible path length TPS (recommended) "
-        "or fixed path length TPS?", options=list(tps_types.keys())
-    )
-    network_class = tps_types[network_type]
-
-    if network_type == FIXED:
-        pathlength = _get_pathlength(wizard)
-        network_class = partial(network_class, length=pathlength)
-
-    initial_states = _select_states(wizard, 'initial')
-    final_states = _select_states(wizard, 'final')
-
-    # TODO: summary
-
-    obj = network_class(initial_states, final_states)
-    return obj
 
 def _get_network(wizard):
     if len(wizard.networks) == 0:
@@ -121,16 +29,3 @@ def tps_scheme(wizard, network=None):
     scheme.append(shooting_strategy)
     scheme.append(global_strategy)
     return scheme
-
-def tps_setup(wizard):
-    network = tps_network(wizard)
-    scheme = tps_scheme(wizard, network)
-    # name it
-    # provide final info on how to use it
-    return scheme
-
-
-if __name__ == "__main__":
-    from paths_cli.wizard.wizard import Wizard
-    wiz = Wizard({'tps_network': ('networks', 1, '='),
-                  'tps_scheme': ('schemes', 1, '=')})

--- a/paths_cli/wizard/tps.py
+++ b/paths_cli/wizard/tps.py
@@ -13,9 +13,9 @@ def tps_scheme(wizard, network=None):
 
     shooting_strategy = shooting(wizard, network)
 
-    if isinstance(shooting_strategy, paths.MoveScheme):
+    if not isinstance(shooting_strategy, paths.MoveStrategy):
         # this means we got a fixed scheme and can't do strategies
-        return shooting_strategy
+        return shooting_strategy(network=network)
 
     # TODO: add an option for shifting maybe?
     global_strategy = strategies.OrganizeByMoveGroupStrategy()

--- a/paths_cli/wizard/tps.py
+++ b/paths_cli/wizard/tps.py
@@ -3,18 +3,6 @@ from paths_cli.wizard.core import get_missing_object
 from paths_cli.wizard.shooting import shooting
 from functools import partial
 
-def _get_network(wizard):
-    if len(wizard.networks) == 0:
-        network = tps_network(wizard)
-    elif len(wizard.networks) == 1:
-        network = list(wizard.networks.values())[0]
-    else:
-        networks = list(wizard.networks.keys())
-        sel = wizard.ask_enumerate("Which network would you like to use?",
-                                   options=networks)
-        network = wizard.networks[sel]
-    return network
-
 def tps_scheme(wizard, network=None):
     import openpathsampling as paths
     from openpathsampling import strategies

--- a/paths_cli/wizard/tps.py
+++ b/paths_cli/wizard/tps.py
@@ -6,7 +6,7 @@ from paths_cli.wizard.volumes import volumes
 from functools import partial
 
 def tps_network(wizard):
-    raise NotImplementedError("Still need to add other network choic")
+    raise NotImplementedError("Still need to add other network choices")
 
 
 def tps_scheme(wizard, network=None):

--- a/paths_cli/wizard/tps.py
+++ b/paths_cli/wizard/tps.py
@@ -11,7 +11,7 @@ def tps_scheme(wizard, network=None):
         network = get_missing_object(wizard, wizard.networks, 'network',
                                      tps_network)
 
-    shooting_strategy = shooting(wizard, network)
+    shooting_strategy = shooting(wizard, network=network)
 
     if not isinstance(shooting_strategy, paths.MoveStrategy):
         # this means we got a fixed scheme and can't do strategies

--- a/paths_cli/wizard/tps.py
+++ b/paths_cli/wizard/tps.py
@@ -17,6 +17,7 @@ from paths_cli.wizard.shooting import (
 from functools import partial
 
 def _select_states(wizard, state_type):
+    # TODO: change this significantly ... I dislike in usage
     states = []
     do_another = True
     while do_another:
@@ -39,6 +40,7 @@ def _select_states(wizard, state_type):
     return state_objs
 
 def _get_pathlength(wizard):
+    # redo as get_custom_eval with int type
     pathlength = None
     while pathlength is None:
         len_str = wizard.ask("How long (in frames) do you want yout "
@@ -58,6 +60,7 @@ def flex_length_tps_network(wizard):
     return network
 
 def fixed_length_tps_network(wizard):
+    import openpathsampling as paths
     pathlength = _get_pathlength(wizard)
     initial_states = _select_states(wizard, 'initial')
     final_states = _select_states(wizard, 'final')
@@ -74,12 +77,11 @@ def tps_network(wizard):
         FIXED: paths.FixedLengthTPSNetwork,
     }
     network_type = None
-    while network_type is None:
-        network_type = wizard.ask_enumerate(
-            "Do you want to do flexible path length TPS (recommended) "
-            "or fixed path length TPS?", options=list(tps_types.keys())
-        )
-        network_class = tps_types[network_type]
+    network_type = wizard.ask_enumerate(
+        "Do you want to do flexible path length TPS (recommended) "
+        "or fixed path length TPS?", options=list(tps_types.keys())
+    )
+    network_class = tps_types[network_type]
 
     if network_type == FIXED:
         pathlength = _get_pathlength(wizard)
@@ -102,7 +104,7 @@ def _get_network(wizard):
         networks = list(wizard.networks.keys())
         sel = wizard.ask_enumerate("Which network would you like to use?",
                                    options=networks)
-        network = wizard.networks[network]
+        network = wizard.networks[sel]
     return network
 
 def tps_scheme(wizard, network=None):
@@ -120,9 +122,6 @@ def tps_scheme(wizard, network=None):
     scheme.append(global_strategy)
     return scheme
 
-def tps_finalize(wizard):
-    pass
-
 def tps_setup(wizard):
     network = tps_network(wizard)
     scheme = tps_scheme(wizard, network)
@@ -134,5 +133,4 @@ def tps_setup(wizard):
 if __name__ == "__main__":
     from paths_cli.wizard.wizard import Wizard
     wiz = Wizard({'tps_network': ('networks', 1, '='),
-                  'tps_scheme': ('schemes', 1, '='),
-                  'tps_finalize': (None, None, None)})
+                  'tps_scheme': ('schemes', 1, '=')})

--- a/paths_cli/wizard/two_state_tps.py
+++ b/paths_cli/wizard/two_state_tps.py
@@ -1,8 +1,8 @@
+from paths_cli.wizard.volumes import volumes
+from paths_cli.wizard.tps import tps_scheme
 from paths_cli.wizard.steps import (
     SINGLE_ENGINE_STEP, CVS_STEP, WizardStep
 )
-from paths_cli.wizard.volumes import volumes
-from paths_cli.wizard.tps import tps_scheme
 from paths_cli.wizard.wizard import Wizard
 
 def two_state_tps(wizard, fixed_length=False):

--- a/paths_cli/wizard/two_state_tps.py
+++ b/paths_cli/wizard/two_state_tps.py
@@ -1,0 +1,33 @@
+from paths_cli.wizard.steps import (
+    SINGLE_ENGINE_STEP, CVS_STEP, WizardStep
+)
+from paths_cli.wizard.volumes import volumes
+from paths_cli.wizard.tps import tps_scheme
+from paths_cli.wizard.wizard import Wizard
+
+def two_state_tps(wizard, fixed_length=False):
+    import openpathsampling as paths
+    wizard.say("Now let's define the stable states for your system. "
+               "Let's start with your initial state.")
+    initial_state = volumes(wizard, as_state=True, intro="")
+    wizard.register(initial_state, 'initial state', 'states')
+    wizard.say("Next let's define your final state.")
+    final_state = volumes(wizard, as_state=True, intro="")
+    wizard.register(final_state, 'final state', 'states')
+    if fixed_length:
+        ...
+    else:
+        network = paths.TPSNetwork(initial_state, final_state)
+    scheme = tps_scheme(wizard, network=network)
+    return scheme
+
+
+TWO_STATE_TPS_WIZARD = Wizard([
+    SINGLE_ENGINE_STEP,
+    CVS_STEP,
+    WizardStep(func=two_state_tps,
+               display_name="TPS setup",
+               store_name='schemes',
+               minimum=1,
+               maximum=1)
+])

--- a/paths_cli/wizard/two_state_tps.py
+++ b/paths_cli/wizard/two_state_tps.py
@@ -15,7 +15,7 @@ def two_state_tps(wizard, fixed_length=False):
     final_state = volumes(wizard, as_state=True, intro="")
     wizard.register(final_state, 'final state', 'states')
     if fixed_length:
-        ...
+        ...  # no-cov  (will add this later)
     else:
         network = paths.TPSNetwork(initial_state, final_state)
     scheme = tps_scheme(wizard, network=network)

--- a/paths_cli/wizard/volumes.py
+++ b/paths_cli/wizard/volumes.py
@@ -50,22 +50,7 @@ def cv_defined_volume(wizard):
     wizard.say("A CV-defined volume allows an interval in a CV.")
     cv = wizard.obj_selector('cvs', "CV", cvs)
     period_min = period_max = lambda_min = lambda_max = None
-    is_periodic = None
-    while is_periodic is None:
-        is_periodic_char = wizard.ask("Is this CV periodic?",
-                                      options=["[Y]es", "[N]o"])
-        is_periodic = {'y': True, 'n': False}[is_periodic_char]
-
-    if is_periodic:
-        while period_min is None:
-            period_min = wizard.ask_custom_eval(
-                "What is the lower bound of the period?"
-            )
-        while period_max is None:
-            period_max = wizard.ask_custom_eval(
-                "What is the upper bound of the period?"
-            )
-
+    is_periodic = cv.is_periodic
     volume_bound_str = ("What is the {bound} allowed value for "
                         f"'{cv.name}' in this volume?")
 
@@ -82,7 +67,7 @@ def cv_defined_volume(wizard):
     if is_periodic:
         vol = paths.PeriodicCVDefinedVolume(
             cv, lambda_min=lambda_min, lambda_max=lambda_max,
-            period_min=period_min, period_max=period_max
+            period_min=cv.period_min, period_max=cv.period_max
         )
     else:
         vol = paths.CVDefinedVolume(

--- a/paths_cli/wizard/volumes.py
+++ b/paths_cli/wizard/volumes.py
@@ -1,0 +1,125 @@
+import operator
+from paths_cli.wizard.core import interpret_req
+from paths_cli.wizard.cvs import cvs
+
+def _vol_intro(wizard, as_state):
+    if as_state:
+        req = wizard.requirements['states']
+        if len(wizard.states) == 0:
+            intro = ("Now let's define stable states for your system. "
+                     f"You'll need to define {interpret_req(req)} of them.")
+        else:
+            intro = "Okay, let's define another stable state."
+    else:
+        intro = None
+    return intro
+
+def _binary_func_volume(wizard, op):
+    wizard.say("Let's make the first constituent volume:")
+    vol1 = volumes(wizard)
+    wizard.say(f"The first volume is:\n{str(vol1)}")
+    wizard.say("Let's make the second constituent volume:")
+    vol2 = volumes(wizard)
+    wizard.say(f"The second volume is:\n{str(vol2)}")
+    vol = op(vol1, vol2)
+    wizard.say(f"Created a volume:\n{str(vol)}")
+    return vol
+
+def intersection_volume(wizard):
+    wizard.say("This volume will be the intersection of two other volumes. "
+               "This means that it only allows phase space points that are "
+               "in both of the constituent volumes.")
+    return _binary_func_volume(wizard, operator.__and__)
+
+def union_volume(wizard):
+    wizard.say("This volume will be the union of two other volumes. "
+               "This means that it allows phase space points that are in "
+               "either of the constituent volumes.")
+    return _binary_func_volume(wizard, operator.__or__)
+
+def negated_volume(wizard):
+    wizard.say("This volume will be everything not in the subvolume. ")
+    wizard.say("Let's make the subvolume.")
+    subvol = volumes(wizard)
+    vol = ~subvol
+    wizard.say(f"Created a volume:\n{str(vol)}")
+    return vol
+
+def cv_defined_volume(wizard):
+    import openpathsampling as paths
+    wizard.say("A CV-defined volume allows an interval in a CV.")
+    cv = wizard.obj_selector('cvs', "CV", cvs)
+    period_min = period_max = lambda_min = lambda_max = None
+    is_periodic = None
+    while is_periodic is None:
+        is_periodic_char = wizard.ask("Is this CV periodic?",
+                                      options=["[Y]es", "[N]o"])
+        is_periodic = {'y': True, 'n': False}
+
+    if is_periodic:
+        while period_min is None:
+            period_min = wizard.ask_custom_eval(
+                "What is the lower bound of the period?"
+            )
+        while period_max is None:
+            period_max = wizard.ask_custom_eval(
+                "What is the upper bound of the period?"
+            )
+
+    volume_bound_str = ("What is the {bound} allowed value for "
+                        f"'{cv.name}' in this volume?")
+
+    while lambda_min is None:
+        lambda_min = wizard.ask_custom_eval(
+            volume_bound_str.format(bound="minimum")
+        )
+
+    while lambda_max is None:
+        lambda_max = wizard.ask_custom_eval(
+            volume_bound_str.format(bound="maximum")
+        )
+
+    if is_periodic:
+        vol = paths.PeriodicCVDefinedVolume(
+            cv, lambda_min=lambda_min, lambda_max=lambda_max,
+            period_min=period_min, period_max=period_max
+        )
+    else:
+        vol = paths.CVDefinedVolume(
+            cv, lambda_min=lambda_min, lambda_max=lambda_max,
+        )
+    return vol
+
+
+SUPPORTED_VOLUMES = {
+    'CV-defined volume (allowed values of CV)': cv_defined_volume,
+    'Intersection of two volumes (must be in both)': intersection_volume,
+    'Union of two volumes (must be in at least one)': union_volume,
+    'Complement of a volume (not in given volume)': negated_volume,
+}
+
+def volumes(wizard, as_state=False):
+    intro = _vol_intro(wizard, as_state)
+    if intro is not None:
+        wizard.say(_vol_intro(wizard, as_state))
+
+    wizard.say("You can describe this as either a range of values for some "
+               "CV, or as some combination of other such volumes "
+               "(i.e., intersection or union).")
+    obj = "state" if as_state else "volume"
+    vol = None
+    while vol is None:
+        vol_type = wizard.ask_enumerate(
+            f"What describes this {obj}?",
+            options=list(SUPPORTED_VOLUMES.keys())
+        )
+        vol = SUPPORTED_VOLUMES[vol_type](wizard)
+
+    return vol
+
+
+if __name__ == "__main__":
+    from paths_cli.wizard.wizard import Wizard
+    wiz = Wizard({'states': ('states', 1, '+')})
+    volumes(wiz, as_state=True)
+

--- a/paths_cli/wizard/volumes.py
+++ b/paths_cli/wizard/volumes.py
@@ -83,10 +83,12 @@ SUPPORTED_VOLUMES = {
     'Complement of a volume (not in given volume)': negated_volume,
 }
 
-def volumes(wizard, as_state=False):
-    intro = _vol_intro(wizard, as_state)
-    if intro is not None:
-        wizard.say(_vol_intro(wizard, as_state))
+def volumes(wizard, as_state=False, intro=None):
+    if intro is None:
+        intro = _vol_intro(wizard, as_state)
+
+    if intro:  # disallow None and ""
+        wizard.say(intro)
 
     wizard.say("You can describe this as either a range of values for some "
                "CV, or as some combination of other such volumes "

--- a/paths_cli/wizard/volumes.py
+++ b/paths_cli/wizard/volumes.py
@@ -38,7 +38,7 @@ def union_volume(wizard):
     return _binary_func_volume(wizard, operator.__or__)
 
 def negated_volume(wizard):
-    wizard.say("This volume will be everything not in the subvolume. ")
+    wizard.say("This volume will be everything not in the subvolume.")
     wizard.say("Let's make the subvolume.")
     subvol = volumes(wizard)
     vol = ~subvol
@@ -54,7 +54,7 @@ def cv_defined_volume(wizard):
     while is_periodic is None:
         is_periodic_char = wizard.ask("Is this CV periodic?",
                                       options=["[Y]es", "[N]o"])
-        is_periodic = {'y': True, 'n': False}
+        is_periodic = {'y': True, 'n': False}[is_periodic_char]
 
     if is_periodic:
         while period_min is None:

--- a/paths_cli/wizard/volumes.py
+++ b/paths_cli/wizard/volumes.py
@@ -105,8 +105,7 @@ def volumes(wizard, as_state=False, intro=None):
     return vol
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # no-cov
     from paths_cli.wizard.wizard import Wizard
     wiz = Wizard({'states': ('states', 1, '+')})
     volumes(wiz, as_state=True)
-

--- a/paths_cli/wizard/volumes.py
+++ b/paths_cli/wizard/volumes.py
@@ -4,7 +4,7 @@ from paths_cli.wizard.cvs import cvs
 
 def _vol_intro(wizard, as_state):
     if as_state:
-        req = wizard.requirements['states']
+        req = wizard.requirements['state']
         if len(wizard.states) == 0:
             intro = ("Now let's define stable states for your system. "
                      f"You'll need to define {interpret_req(req)} of them.")

--- a/paths_cli/wizard/volumes.py
+++ b/paths_cli/wizard/volumes.py
@@ -17,12 +17,12 @@ def _vol_intro(wizard, as_state):
 def _binary_func_volume(wizard, op):
     wizard.say("Let's make the first constituent volume:")
     vol1 = volumes(wizard)
-    wizard.say(f"The first volume is:\n{str(vol1)}")
+    wizard.say(f"The first volume is:\n{vol1}")
     wizard.say("Let's make the second constituent volume:")
     vol2 = volumes(wizard)
-    wizard.say(f"The second volume is:\n{str(vol2)}")
+    wizard.say(f"The second volume is:\n{vol2}")
     vol = op(vol1, vol2)
-    wizard.say(f"Created a volume:\n{str(vol)}")
+    wizard.say(f"Created a volume:\n{vol}")
     return vol
 
 def intersection_volume(wizard):
@@ -42,7 +42,7 @@ def negated_volume(wizard):
     wizard.say("Let's make the subvolume.")
     subvol = volumes(wizard)
     vol = ~subvol
-    wizard.say(f"Created a volume:\n{str(vol)}")
+    wizard.say(f"Created a volume:\n{vol}")
     return vol
 
 def cv_defined_volume(wizard):

--- a/paths_cli/wizard/wizard.py
+++ b/paths_cli/wizard/wizard.py
@@ -1,0 +1,224 @@
+import random
+from functools import partial
+import textwrap
+
+from paths_cli.wizard.cvs import cvs
+from paths_cli.wizard.engines import engines
+from paths_cli.wizard.volumes import volumes
+from paths_cli.wizard.tools import yes_no, a_an
+from paths_cli.parsing.core import custom_eval
+from paths_cli.wizard.joke import name_joke
+
+WIZARD_PAGES = {
+    "engines": (engines, "engine"),
+    "cvs": (cvs, "cv"),
+    "states": (partial(volumes, as_state=True), "state"),
+    "tps_network": ...,
+    "tps_scheme": ...,
+    "tps_finalize": ...,
+}
+
+import shutil
+
+class Console:
+    # TODO: add logging so we can output the session
+    def print(self, *content):
+        print(*content)
+
+    def input(self, content):
+        return input(content)
+
+    @property
+    def width(self):
+        return shutil.get_terminal_size((80, 24)).columns
+
+class Wizard:
+    def __init__(self, requirements):
+        self.requirements = requirements
+        self.engines = {}
+        self.cvs = {}
+        self.states = {}
+        self.networks = {}
+        self.schemes = {}
+
+        self.console = Console()
+        self.default = {}
+
+    def _speak(self, content, preface):
+        # we do custom wrapping here
+        width = self.console.width - len(preface)
+        statement = preface + content
+        lines = statement.split("\n")
+        wrapped = textwrap.wrap(lines[0], width=width, subsequent_indent=" "*3)
+        for line in lines[1:]:
+            wrap_line = textwrap.indent(line, " "*3)
+            wrapped.append(wrap_line)
+        self.console.print("\n".join(wrapped))
+
+    def ask(self, question, options=None, default=None, helper=None):
+        result = None
+        while result is None:
+            result = self.console.input("🧙 " + question + " ")
+            self.console.print()
+            if helper and result.startswith("?"):
+                helper(self, result)
+                result = None
+        return result
+
+    def say(self, content, preface="🧙 "):
+        self._speak(content, preface)
+        self.console.print()  # adds a blank line
+
+    def bad_input(self, content, preface="👺 "):
+        # just changes the default preface; maybe print 1st line red?
+        self.say(content, preface)
+
+    def ask_enumerate(self, question, options):
+        self.say(question)
+        opt_string = "\n".join([f" {(i+1):>3}. {opt}"
+                                for i, opt in enumerate(options)])
+        self.say(opt_string, preface=" "*3)
+        result = None
+        while result is None:
+            choice = self.ask("Please select a number.",
+                              options=[str(i+1)
+                                       for i in range(len(options))])
+            try:
+                num = int(choice) - 1
+                result = options[num]
+            except Exception:
+                self.bad_input(f"Sorry, '{choice}' is not a valid option.")
+                result = None
+
+        return result
+
+    # this should match the args for wizard.ask
+    def ask_custom_eval(self, question, options=None, default=None,
+                        helper=None):
+        result = None
+        while result is None:
+            as_str = self.ask(question, options=options, default=default,
+                              helper=helper)
+            try:
+                result = custom_eval(as_str)
+            except Exception as e:
+                self.exception(f"Sorry, I couldn't understand the input "
+                               f"'{as_str}'", e)
+                result = None
+
+        return result
+
+    def obj_selector(self, store_name, text_name, create_func):
+        opts = {name: lambda wiz: obj
+                for name, obj in getattr(self, store_name).items()}
+        create_new = f"Create a new {text_name}"
+        opts[create_new] = create_func
+        sel = self.ask_enumerate(f"Which {text_name} would you like to "
+                                 "use?", list(opts.keys()))
+        obj = opts[sel](self)
+        if sel == create_new:
+            obj = self.register(obj, text_name, store_name)
+        return obj
+
+    def exception(self, msg, exception):
+        self.bad_input(msg + "\nHere's the error I got:\n" + str(exception))
+
+    def _req_allows_another(self, req):
+        store, num, direction = req
+        if store is None:
+            return True
+
+        count = len(getattr(self, store))
+        result = {'=': count < num,
+                  '+': True,
+                  '-': count < num}[direction]
+        return result
+
+    def name(self, obj, obj_type, store_name, default=None):
+        self.say(f"Now let's name your {obj_type}.")
+        name = None
+        while name is None:
+            name = self.ask("What do you want to call it?")
+            if name in getattr(self, store_name):
+                self.bad_input(f"Sorry, you already have {a_an(obj_type)} "
+                               f"named {name}. Please try another name.")
+                name = None
+
+        obj = obj.named(name)
+
+        self.say(f"'{name}' is a good name for {a_an(obj_type)} {obj_type}. "
+                 + name_joke(name, obj_type))
+        return obj
+
+
+    def register(self, obj, obj_type, store_name):
+        if not obj.is_named:
+            obj = self.name(obj, obj_type, store_name)
+        store_dict = getattr(self, store_name)
+        store_dict[obj.name] = obj
+        return obj
+
+    def save_to_file(self):
+        filename = None
+        while filename is None:
+            filename = self.ask("Where would you like to save your setup "
+                                "database?")
+            if not filename.endswith(".db"):
+                self.bad_input("Files produced by this wizard must end in "
+                               "'.db'.")
+                filename = None
+                continue
+
+            if os.path.exists(filename):
+                overwrite = self.ask("{filename} exists. Overwrite it?",
+                                     options=["[Y]es", "[N]o"])
+                overwrite = yes_no[overwrite]
+                if not overwrite:
+                    filename = None
+                    continue
+
+            try:
+                storage = Storage(filename, mode='w')
+            except Exception as e:
+                self.exception(FILE_LOADING_ERROR_MSG, e)
+            else:
+                self._do_storage(storage)
+
+    def _do_storage(self, storage):
+        pass
+
+    def run_wizard(self):
+        for page, req in self.requirements.items():
+            store_name, _, _ = req
+            while self._req_allows_another(req):
+                func, obj_type = WIZARD_PAGES[page]
+                obj = func(self)
+                self.register(obj, obj_type, store_name)
+
+
+TPS_WIZARD = Wizard({
+    # WIZARD_PAGE_NAME: (store_name, num, exact/at least/at most)
+    'engines': ('engines', 1, '='),
+    'cvs': ('cvs', 1, '+'),
+    'states': ('states', 2, '+'),
+    'tps_network': ('metworks', 1, '='),
+    'tps_scheme': ('schemes', 1, '='),
+    'tps_finalize': (None, None, None),
+})
+
+TIS_WIZARD = Wizard({
+    'engines': ('engines', 1, '='),
+    'cvs': ('cvs', 1, '+'),
+    'states': ('states', 2, '='),
+    'tis_network': (1, '='),
+    'tis_scheme': (1, '='),
+    'tis_finalize': (),
+})
+
+MSTIS_WIZARD = Wizard({
+    'engines': (1, '='),
+    'cvs': (1, '+'),
+    'states': (2, '='),
+    'mstis_network': (1, '='),
+    'mstis_scheme': (1, '='),
+})

--- a/paths_cli/wizard/wizard.py
+++ b/paths_cli/wizard/wizard.py
@@ -9,7 +9,7 @@ from paths_cli.wizard.errors import (
     FILE_LOADING_ERROR_MSG, RestartObjectException
 )
 from paths_cli.wizard.joke import name_joke
-from paths_cli.parsing.core import custom_eval
+from paths_cli.parsing.tools import custom_eval
 
 import shutil
 

--- a/paths_cli/wizard/wizard.py
+++ b/paths_cli/wizard/wizard.py
@@ -136,7 +136,6 @@ class Wizard:
         sel = self.ask_enumerate(f"Which {text_name} would you like to "
                                  "use?", list(opts.keys()))
         obj = opts[sel](self)
-        print(sel, obj)
         if sel == create_new:
             obj = self.register(obj, text_name, store_name)
         return obj

--- a/paths_cli/wizard/wizard.py
+++ b/paths_cli/wizard/wizard.py
@@ -101,6 +101,9 @@ class Wizard:
             choice = self.ask("Please select a number:",
                               options=[str(i+1)
                                        for i in range(len(options))])
+            if choice in options:
+                return choice
+
             try:
                 num = int(choice) - 1
                 result = options[num]

--- a/paths_cli/wizard/wizard.py
+++ b/paths_cli/wizard/wizard.py
@@ -79,6 +79,11 @@ class Wizard:
         self._speak(content, preface)
         self.console.print()  # adds a blank line
 
+    def start(self, content):
+        # eventually, this will tweak so that we preface with a line and use
+        # green text here
+        self.say(content)
+
     def bad_input(self, content, preface="👺 "):
         # just changes the default preface; maybe print 1st line red?
         self.say(content, preface)
@@ -228,7 +233,7 @@ class Wizard:
 
 
 TPS_WIZARD = Wizard({
-    # WIZARD_PAGE_NAME: (store_name, num, exact/at least/at most)
+    # WIZARD_PAGE_NAME: (store_name, min_num, max_num)
     'engines': ('engines', 1, 1),
     'cvs': ('cvs', 1, float('inf')),
     'states': ('states', 2, float('inf')),

--- a/paths_cli/wizard/wizard.py
+++ b/paths_cli/wizard/wizard.py
@@ -217,7 +217,7 @@ class Wizard:
             for obj in store.values():
                 storage.save(obj)
 
-        self.say("Success! Everthing has been stored in your file.")
+        self.say("Success! Everything has been stored in your file.")
 
     def _req_do_another(self, req):
         store, min_, max_ = req

--- a/paths_cli/wizard/wizard.py
+++ b/paths_cli/wizard/wizard.py
@@ -16,7 +16,7 @@ from paths_cli.wizard.joke import name_joke
 
 import shutil
 
-class Console:
+class Console:  # no-cov
     # TODO: add logging so we can output the session
     def print(self, *content):
         print(*content)
@@ -45,7 +45,7 @@ class Wizard:
         self.default = {}
         self._patched = False  # if we've done the monkey-patching
 
-    def _patch(self):
+    def _patch(self):  # no-cov
         import openpathsampling as paths
         from openpathsampling.experimental.storage import monkey_patch_all
         if not self._patched:
@@ -53,7 +53,7 @@ class Wizard:
             paths.InterfaceSet.simstore = True
             self._patched = True
 
-    def debug(content):
+    def debug(content):  # no-cov
         self.console.print(content)
 
     def _speak(self, content, preface):

--- a/paths_cli/wizard/wizard.py
+++ b/paths_cli/wizard/wizard.py
@@ -242,6 +242,22 @@ class Wizard:
                 self.bad_input("Sorry, I didn't understand that.")
         return do_another
 
+    def _do_one(self, step, req):
+        try:
+            obj = step.func(self)
+        except RestartObjectException:
+            self.say("Okay, let's try that again.")
+            return True
+        self.register(obj, step.display_name, step.store_name)
+        requires_another, allows_another = self._req_do_another(req)
+        if requires_another:
+            do_another = True
+        elif not requires_another and allows_another:
+            do_another = self._ask_do_another(step.display_name)
+        else:
+            do_another = False
+        return do_another
+
     def run_wizard(self):
         self.start("Hi! I'm the OpenPathSampling Wizard.")
         # TODO: next line is only temporary
@@ -251,20 +267,7 @@ class Wizard:
             req = step.store_name, step.minimum, step.maximum
             do_another = True
             while do_another:
-                try:
-                    obj = step.func(self)
-                except RestartObjectException:
-                    self.say("Okay, let's try that again.")
-                    continue
-                self.register(obj, step.display_name, step.store_name)
-                requires_another, allows_another = self._req_do_another(req)
-                if requires_another:
-                    do_another = True
-                elif not requires_another and allows_another:
-                    do_another = self._ask_do_another(step.display_name)
-                else:
-                    do_another = False
-
+                do_another = self._do_one(step, req)
         storage = self.get_storage()
         self.save_to_file(storage)
 

--- a/paths_cli/wizard/wizard.py
+++ b/paths_cli/wizard/wizard.py
@@ -3,12 +3,6 @@ import os
 from functools import partial
 import textwrap
 
-from paths_cli.wizard.cvs import cvs
-from paths_cli.wizard.engines import engines
-from paths_cli.wizard.volumes import volumes
-from paths_cli.wizard.tps import (
-    flex_length_tps_network, fixed_length_tps_network, tps_scheme
-)
 from paths_cli.wizard.tools import yes_no, a_an
 from paths_cli.wizard.core import get_object
 from paths_cli.wizard.errors import (
@@ -247,6 +241,9 @@ class Wizard:
         return do_another
 
     def run_wizard(self):
+        self.start("Hi! I'm the OpenPathSampling Wizard.")
+        # TODO: next line is only temporary
+        self.say("Today I'll help you set up a 2-state TPS simulation.")
         self._patch()  # try to hide the slowness of our first import
         for step in self.steps:
             req = step.store_name, step.minimum, step.maximum
@@ -269,45 +266,9 @@ class Wizard:
         storage = self.get_storage()
         self.save_to_file(storage)
 
-from collections import namedtuple
-WizardStep = namedtuple('WizardStep', ['func', 'display_name', 'store_name',
-                                       'minimum', 'maximum'])
-
-SINGLE_ENGINE_STEP = WizardStep(func=engines,
-                                display_name="engine",
-                                store_name="engines",
-                                minimum=1,
-                                maximum=1)
-
-CVS_STEP = WizardStep(func=cvs,
-                      display_name="CV",
-                      store_name='cvs',
-                      minimum=1,
-                      maximum=float('inf'))
-
-MULTIPLE_STATES_STEP = WizardStep(func=partial(volumes, as_state=True),
-                                  display_name="state",
-                                  store_name="states",
-                                  minimum=2,
-                                  maximum=float('inf'))
-
-FLEX_LENGTH_TPS_WIZARD = Wizard([
-    SINGLE_ENGINE_STEP,
-    CVS_STEP,
-    MULTIPLE_STATES_STEP,
-    WizardStep(func=flex_length_tps_network,
-               display_name="network",
-               store_name="networks",
-               minimum=1,
-               maximum=1),
-    WizardStep(func=tps_scheme,
-               display_name="move scheme",
-               store_name="schemes",
-               minimum=1,
-               maximum=1),
-])
 
 # FIXED_LENGTH_TPS_WIZARD
+# MULTIPLE_STATE_TPS_WIZARD
 # TWO_STATE_TIS_WIZARD
 # MULTIPLE_STATE_TIS_WIZARD
 # MULTIPLE_INTERFACE_SET_TIS_WIZARD


### PR DESCRIPTION
This will add an interactive setup wizard to the OPS CLI. The wizard will guide users through the process of setting up simulation objects to use in a simulation, and will save the created objects to a SimStore database (hopefully with a little fun along the way). This PR will have support for a wizard to do flexible-length TPS simulation using an OpenMM engine and MDTraj CVs (tested by stepping through the setup for alanine dipeptide).