### PR TITLE
Fix tests for moved CVs in OPS 1.5

### DIFF
--- a/paths_cli/tests/test_parameters.py
+++ b/paths_cli/tests/test_parameters.py
@@ -38,6 +38,7 @@ def undo_monkey_patch(stored_functions):
     import importlib
     importlib.reload(paths.netcdfplus)
     importlib.reload(paths.collectivevariable)
+    importlib.reload(paths.collectivevariables)
     importlib.reload(paths)
 
 


### PR DESCRIPTION
Changes related to CVs being imported at `openpathsampling.collectivevariables` instead of `.collectivevariable` meant that if you patch and unpatch to support SimStore, you get the same base classes defined at two different memory addresses, which caused non-obvious problems when calling `super`. This PR fixes.

This is only an issue for situations like unit tests, where it is necessary to unpatch for SimStore after patching.