### PR TITLE
[WIP] `info` command

### DIFF
--- a/paths_cli/commands/info.py
+++ b/paths_cli/commands/info.py
@@ -1,0 +1,51 @@
+import click
+
+import importlib
+
+def get_module_version(module_name, version_path="version.full_version"):
+    try:
+        mod = importlib.import_module(module_name)
+    except ImportError:
+        return "NOT INSTALLED"
+    attr_seq = version_path.split('.')
+    current = mod
+    for attr in attr_seq:
+        current = getattr(current, attr)
+    return current
+
+LABEL_TO_MODULE = {
+    'OpenPathSampling': 'openpathsampling',
+    'OpenPathSampling CLI': 'paths_cli',
+    'OpenMM': 'simtk.openmm'
+}
+
+NONDEFAULT_VERSION_PATHS = {
+}
+
+def python_module_info(label):
+    module = LABEL_TO_MODULE[label]
+    try:
+        version_path = NONDEFAULT_VERSION_PATHS[label]
+    except KeyError:
+        version_path = 'version.full_version'
+    version = get_module_version(module, version_path)
+    return label, version
+
+FORMAT = "{label}: {version}"
+
+@click.command(
+    'info',
+    short_help="Environment information",
+)
+def info():
+    OPS_LABELS = ['OpenPathSampling', 'OpenPathSampling CLI']
+    OPENMM_LABELS = ['OpenMM']
+
+    for label in OPS_LABELS:
+        label, version = python_module_info(label)
+        print(FORMAT.format(label=label, version=version))
+
+
+CLI = info
+SECTION = "Miscellaneous"
+REQUIRES_OPS = (1, 0)


### PR DESCRIPTION
This will create a command `openpathsampling info` which reports versions of OPS, the OPS CLI, and various tools OPS integrates with (or will report that the tool can't be found).

This isn't intended to be a full listing of OPS dependencies -- the installation manager (`conda` or `pip`) should still handle that. However, this might be extended to include other useful information (e.g., if OpenMM is installed, which platforms are available?) that helps debug user problems.