### PR TITLE
New plugin infrastructure

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -8,23 +8,33 @@ There are two possible ways to distribute plugins (file plugins and
 namespace plugins), but a given plugin script could be distributed either
 way. 
 
-Writing a plugin script
------------------------
+Writing a command plugin
+------------------------
 
-An OPS plugin is simply a Python module that follows a few rules.
+To write an OPS command plugin, you simply need to create an instance of
+:class:`paths_cli.OPSCommandPlugin` and to install the module in a location
+where the CLI knows to look for it. The input parameters to
+``OPSCommandPlugin`` are:
 
-* It must define a variable ``CLI`` that is the main CLI function is
-  assigned to.
-* It must define a variable ``SECTION`` to determine where to show it in
-  help (what kind of command it is). Valid values are ``"Simulation"``,
-  ``"Analysis"``, ``"Miscellaneous"``, or ``"Workflow"``. If ``SECTION`` is
-  defined but doesn't have one of these values, it won't show in
-  ``openpathsampling --help``, but might still be usable. If your command
-  doesn't show in the help, carefully check your spelling of the ``SECTION``
-  variable.
-* The main CLI function must be decorated as a ``click.command``.
-* (If distributed as a file plugin) It must be possible to ``exec`` it in an
-  empty namespace (mainly, this can mean no relative imports).
+* ``command``: This is the main CLI function for the subcommand. It must be
+  decorated as a ``click.Command``.
+* ``section``: This is a string to determine where to show it in help (what
+  kind of command it is).  Valid values are ``"Simulation"``,
+  ``"Analysis"``, ``"Miscellaneous"``, or ``"Workflow"``. If ``section``
+  doesn't have one of these values, it won't show in ``openpathsampling
+  --help``, but might still be usable. If your command doesn't show in the
+  help, carefully check your spelling of the ``section`` variable.
+* ``requires_ops`` (optional, default ``(1, 0)``): Minimum allowed version
+  of OpenPathSampling. Note that this is currently informational only, and
+  has no effect on functionality.
+* ``requires_cli`` (optional, default ``(0, 3)``): Minimum allowed version
+  of the OpenPathSampling CLI.  Note that this is currently informational
+  only, and has no effect on functionality.
+
+
+If you distribute your plugin as a file-based plugin, be aware that it must
+be possible to ``exec`` it in an empty namespace (mainly, this can mean no
+relative imports).
 
 As a suggestion, I (DWHS) tend to structure my plugins as follows:
 
@@ -41,16 +51,15 @@ As a suggestion, I (DWHS) tend to structure my plugins as follows:
         ...
         return final_status, simulation
 
-    CLI = plugin
-    SECTION = "MySection"
+    PLUGIN = OPSCommandPlugin(command=plugin, section="MySection")
 
 The basic idea is that there's a ``plugin_main`` function that is based on
 pure OPS, using only inputs that OPS can immediately understand (no need to
 process the command line). This is easy to develop/test with OPS. Then
 there's a wrapper function whose sole purpose is to convert the command line
 parameters to something OPS can understand (using the ``get`` method). This
-wrapper is the ``CLI`` variable. Give it an allowed ``SECTION``, and the
-plugin is ready!
+wrapper is the ``command`` in you ``OPSCommandPlugin``. Also provide an
+allowed ``section``, and the plugin is ready!
 
 The result is that plugins are astonishingly easy to develop, once you have
 the scientific code implemented in a library. This structure also makes it

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -17,7 +17,7 @@ where the CLI knows to look for it. The input parameters to
 ``OPSCommandPlugin`` are:
 
 * ``command``: This is the main CLI function for the subcommand. It must be
-  decorated as a ``click.Command``.
+  decorated as a ``click.command``.
 * ``section``: This is a string to determine where to show it in help (what
   kind of command it is).  Valid values are ``"Simulation"``,
   ``"Analysis"``, ``"Miscellaneous"``, or ``"Workflow"``. If ``section``
@@ -103,5 +103,4 @@ namespace.
 
 .. _native namespace packages:
   https://packaging.python.org/guides/packaging-namespace-packages/#native-namespace-packages
-
 

--- a/example_plugins/one_pot_tps.py
+++ b/example_plugins/one_pot_tps.py
@@ -1,4 +1,5 @@
 import click
+from paths_cli import OPSCommandPlugin
 from paths_cli.parameters import (INPUT_FILE, OUTPUT_FILE, ENGINE, STATES,
                                   N_STEPS_MC, INIT_SNAP)
 from paths_cli.commands.visit_all import visit_all_main
@@ -44,6 +45,15 @@ def one_pot_tps_main(output_storage, states, engine, engine_hot,
                                     equil_multiplier, equil_extra)
     return pathsampling_main(output_storage, scheme, equil_set, nsteps)
 
+# these lines enable this plugin to support OPS CLI < 0.3
 CLI = one_pot_tps
 SECTION = "Workflow"
 REQUIRES_OPS = (1, 2)
+
+# these lines enable this plugin to support OPS CLI >= 0.3
+PLUGIN = OPSCommandPlugin(
+    command=one_pot_tps,
+    section="Workflow",
+    requires_ops=(1, 2),
+    requires_cli=(0, 3)
+)

--- a/example_plugins/tps.py
+++ b/example_plugins/tps.py
@@ -1,4 +1,5 @@
 import click
+from paths_cli import OPSCommandPlugin
 from paths_cli.parameters import (
     INPUT_FILE, OUTPUT_FILE, ENGINE, STATES, INIT_CONDS, N_STEPS_MC
 )
@@ -40,8 +41,17 @@ def tps_main(engine, states, init_traj, output_storage, n_steps):
     return simulation.sample_set, simulation
 
 
+# these lines enable this plugin to support OPS CLI < 0.3
 CLI = tps
 SECTION = "Simulation"
 
+# these lines enable this plugin to support OPS CLI >= 0.3
+PLUGIN = OPSCommandPlugin(
+    command=tps,
+    section="Simulation"
+)
+
+
+# this allows you to use this as a script, independently of the OPS CLI
 if __name__ == "__main__":
     tps()

--- a/paths_cli/__init__.py
+++ b/paths_cli/__init__.py
@@ -1,3 +1,6 @@
+from .plugin_management import (
+    OPSCommandPlugin,
+)
 from .cli import OpenPathSamplingCLI
 from . import commands
 from . import version

--- a/paths_cli/cli.py
+++ b/paths_cli/cli.py
@@ -13,7 +13,8 @@ import click
 # import click_completion
 # click_completion.init()
 
-from .plugin_management import FilePluginLoader, NamespacePluginLoader
+from .plugin_management import (FilePluginLoader, NamespacePluginLoader,
+                                OPSCommandPlugin)
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
@@ -31,10 +32,10 @@ class OpenPathSamplingCLI(click.MultiCommand):
             ).resolve() / 'cli-plugins')
 
         self.plugin_loaders = [
-            FilePluginLoader(commands),
-            FilePluginLoader(app_dir_plugins(posix=False)),
-            FilePluginLoader(app_dir_plugins(posix=True)),
-            NamespacePluginLoader('paths_cli_plugins')
+            FilePluginLoader(commands, OPSCommandPlugin),
+            FilePluginLoader(app_dir_plugins(posix=False), OPSCommandPlugin),
+            FilePluginLoader(app_dir_plugins(posix=True), OPSCommandPlugin),
+            NamespacePluginLoader('paths_cli_plugins', OPSCommandPlugin)
         ]
 
         plugins = sum([loader() for loader in self.plugin_loaders], [])

--- a/paths_cli/commands/append.py
+++ b/paths_cli/commands/append.py
@@ -1,4 +1,5 @@
 import click
+from paths_cli import OPSCommandPlugin
 from paths_cli.parameters import (
     INPUT_FILE, APPEND_FILE, MULTI_CV, MULTI_ENGINE, MULTI_VOLUME,
     MULTI_NETWORK, MULTI_SCHEME, MULTI_TAG
@@ -55,6 +56,9 @@ def append(input_file, append_file, engine, cv, volume, network, scheme,
     storage.close()
 
 
-CLI = append
-SECTION = "Miscellaneous"
-REQUIRES_OPS = (1, 0)
+PLUGIN = OPSCommandPlugin(
+    command=append,
+    section="Miscellaneous",
+    requires_ops=(1, 0),
+    requires_cli=(0, 3)
+)

--- a/paths_cli/commands/contents.py
+++ b/paths_cli/commands/contents.py
@@ -1,5 +1,6 @@
 import click
 from paths_cli.parameters import INPUT_FILE
+from paths_cli import OPSCommandPlugin
 
 UNNAMED_SECTIONS = ['steps', 'movechanges', 'samplesets', 'trajectories',
                     'snapshots']
@@ -115,3 +116,10 @@ def get_section_string_nameable(section, store, get_named):
 CLI = contents
 SECTION = "Miscellaneous"
 REQUIRES_OPS = (1, 0)
+
+plugin = OPSCommandPlugin(
+    command=contents,
+    section="Miscellaneous",
+    requires_ops=(1, 0),
+    requires_cli=(0, 4)
+)

--- a/paths_cli/commands/contents.py
+++ b/paths_cli/commands/contents.py
@@ -113,13 +113,10 @@ def get_section_string_nameable(section, store, get_named):
                     + _item_or_items(n_unnamed))
     return out_str
 
-CLI = contents
-SECTION = "Miscellaneous"
-REQUIRES_OPS = (1, 0)
 
-plugin = OPSCommandPlugin(
+PLUGIN = OPSCommandPlugin(
     command=contents,
     section="Miscellaneous",
     requires_ops=(1, 0),
-    requires_cli=(0, 4)
+    requires_cli=(0, 3)
 )

--- a/paths_cli/commands/equilibrate.py
+++ b/paths_cli/commands/equilibrate.py
@@ -1,6 +1,7 @@
 import click
 # import openpathsampling as paths
 
+from paths_cli import OPSCommandPlugin
 from paths_cli.parameters import (
     INPUT_FILE, OUTPUT_FILE, INIT_CONDS, SCHEME
 )
@@ -58,6 +59,10 @@ def equilibrate_main(output_storage, scheme, init_conds, multiplier,
     return simulation.sample_set, simulation
 
 
-CLI = equilibrate
-SECTION = "Simulation"
-REQUIRES_OPS = (1, 2)
+PLUGIN = OPSCommandPlugin(
+    command=equilibrate,
+    section="Simulation",
+    requires_ops=(1, 2),
+    requires_cli=(0, 3)
+)
+

--- a/paths_cli/commands/md.py
+++ b/paths_cli/commands/md.py
@@ -1,6 +1,7 @@
 import click
 
 import paths_cli.utils
+from paths_cli import OPSCommandPlugin
 from paths_cli.parameters import (INPUT_FILE, OUTPUT_FILE, ENGINE,
                                   MULTI_ENSEMBLE, INIT_SNAP)
 
@@ -197,7 +198,10 @@ def md_main(output_storage, engine, ensembles, nsteps, initial_frame):
                                      'final_conditions')
     return trajectory, None
 
-CLI = md
-SECTION = "Simulation"
-REQUIRES_OPS = (1, 0)
 
+PLUGIN = OPSCommandPlugin(
+    command=md,
+    section="Simulation",
+    requires_ops=(1, 0),
+    requires_cli=(0, 3)
+)

--- a/paths_cli/commands/pathsampling.py
+++ b/paths_cli/commands/pathsampling.py
@@ -40,3 +40,7 @@ def pathsampling_main(output_storage, scheme, init_conds, n_steps):
 CLI = pathsampling
 SECTION = "Simulation"
 REQUIRES_OPS = (1, 0)
+
+# pathsampling_plugin = paths_cli.CommandPlugin(command=pathsampling,
+                                              # section="Simulation",
+                                              # requires_ops=(1, 0))

--- a/paths_cli/commands/pathsampling.py
+++ b/paths_cli/commands/pathsampling.py
@@ -1,6 +1,7 @@
 import click
 # import openpathsampling as paths
 
+from paths_cli import OPSCommandPlugin
 from paths_cli.parameters import (
     INPUT_FILE, OUTPUT_FILE, INIT_CONDS, SCHEME, N_STEPS_MC
 )
@@ -37,10 +38,9 @@ def pathsampling_main(output_storage, scheme, init_conds, n_steps):
     return simulation.sample_set, simulation
 
 
-CLI = pathsampling
-SECTION = "Simulation"
-REQUIRES_OPS = (1, 0)
-
-# pathsampling_plugin = paths_cli.CommandPlugin(command=pathsampling,
-                                              # section="Simulation",
-                                              # requires_ops=(1, 0))
+PLUGIN = OPSCommandPlugin(
+    command=pathsampling,
+    section="Simulation",
+    requires_ops=(1, 0),
+    requires_cli=(0, 3)
+)

--- a/paths_cli/commands/visit_all.py
+++ b/paths_cli/commands/visit_all.py
@@ -1,6 +1,7 @@
 import click
 
 import paths_cli.utils
+from paths_cli import OPSCommandPlugin
 from paths_cli.parameters import (INPUT_FILE, OUTPUT_FILE, ENGINE, STATES,
                                   INIT_SNAP)
 
@@ -41,6 +42,9 @@ def visit_all_main(output_storage, states, engine, initial_frame):
     return trajectory, None  # no simulation object to return here
 
 
-CLI = visit_all
-SECTION = "Simulation"
-REQUIRES_OPS = (1, 0)
+PLUGIN = OPSCommandPlugin(
+    command=visit_all,
+    section="Simulation",
+    requires_ops=(1, 0),
+    requires_cli=(0, 3)
+)

--- a/paths_cli/param_core.py
+++ b/paths_cli/param_core.py
@@ -269,7 +269,7 @@ class OPSStorageLoadSingle(AbstractLoader):
         parameter. Each should be a callable taking a storage and the string
         input from the CLI, and should return the desired object or None if
         it cannot be found.
-    none_strategies : List[Callable[:class:`openpathsampling.Storage, Any]]
+    none_strategies : List[Callable[:class:`openpathsampling.Storage`, Any]]
         The strategies to be used when the CLI does not provide a value for
         this parameter. Each should be a callable taking a storage, and
         returning the desired object or None if it cannot be found.

--- a/paths_cli/plugin_management.py
+++ b/paths_cli/plugin_management.py
@@ -47,14 +47,14 @@ class OPSPlugin(Plugin):
     Really just to rename ``requires_lib`` to ``requires_ops``.
     """
     def __init__(self, requires_ops, requires_cli):
-        super(OPSPlugin, self).__init__(requires_ops, requires_cli)
+        super().__init__(requires_ops, requires_cli)
 
     @property
     def requires_ops(self):
         return self.requires_lib
 
 
-class OPSCommandPlugin(Plugin):
+class OPSCommandPlugin(OPSPlugin):
     """Plugin for subcommands to the OPS CLI
 
     Parameters

--- a/paths_cli/plugin_management.py
+++ b/paths_cli/plugin_management.py
@@ -3,11 +3,6 @@ import pkgutil
 import importlib
 import os
 
-# TODO: this should be removed
-OPSPlugin = collections.namedtuple(
-    "OPSPlugin", ['name', 'location', 'func', 'section', 'plugin_type']
-)
-
 class PluginRegistrationError(RuntimeError):
     pass
 

--- a/paths_cli/plugin_management.py
+++ b/paths_cli/plugin_management.py
@@ -34,7 +34,7 @@ class Plugin(object):
         )
         if error_condition:  # -no-cov-
             raise PluginRegistrationError(
-                "The plugin " + repr(self) + "has been previously "
+                f"The plugin {repr(self)} has been previously "
                 "registered with different metadata."
             )
         self.location = location
@@ -85,7 +85,7 @@ class OPSCommandPlugin(OPSPlugin):
         return self.command
 
     def __repr__(self):
-        return "OPSCommandPlugin(" + self.name + ")"
+        return f"OPSCommandPlugin({self.name})"
 
 class CLIPluginLoader(object):
     """Abstract object for CLI plugins

--- a/paths_cli/plugin_management.py
+++ b/paths_cli/plugin_management.py
@@ -161,8 +161,9 @@ class FilePluginLoader(CLIPluginLoader):
     search_path : str
         path to the directory that contains plugins (OS-dependent format)
     """
-    def __init__(self, search_path):
-        super().__init__(plugin_type="file", search_path=search_path)
+    def __init__(self, search_path, plugin_class):
+        super().__init__(plugin_type="file", search_path=search_path,
+                         plugin_class=plugin_class)
 
     def _find_candidates(self):
         def is_plugin(filename):
@@ -202,8 +203,9 @@ class NamespacePluginLoader(CLIPluginLoader):
     search_path : str
         namespace (dot-separated) where plugins can be found
     """
-    def __init__(self, search_path):
-        super().__init__(plugin_type="namespace", search_path=search_path)
+    def __init__(self, search_path, plugin_class):
+        super().__init__(plugin_type="namespace", search_path=search_path,
+                         plugin_class=plugin_class)
 
     def _find_candidates(self):
         # based on https://packaging.python.org/guides/creating-and-discovering-plugins/#using-namespace-packages

--- a/paths_cli/plugin_management.py
+++ b/paths_cli/plugin_management.py
@@ -7,6 +7,45 @@ OPSPlugin = collections.namedtuple(
     "OPSPlugin", ['name', 'location', 'func', 'section', 'plugin_type']
 )
 
+
+class Plugin(object):
+    """Generic OPS plugin object"""
+    def __init__(self, requires_ops, requires_cli):
+        self.requires_ops = requires_ops
+        self.requires_cli = requires_cli
+
+
+class CommandPlugin(Plugin):
+    """Plugin for subcommands to the OPS CLI"""
+    def __init__(self, command, section, requires_ops=(1, 0),
+                 requires_cli=(0, 1)):
+        self.command = command
+        self.section = section
+        super().__init__(requires_ops, requires_cli)
+
+    @property
+    def name(self):
+        return self.command.name
+
+
+class ParserPlugin(Plugin):
+    """Plugin to add a new Parser (top-level stage in YAML parsing"""
+    def __init__(self, parser, requires_ops=(1,0), requires_cli=(0,3)):
+        self.parser = parser
+        super().__init__(requires_ops, requires_cli)
+
+
+class InstanceBuilderPlugin(Plugin):
+    """
+    Plugin to add a new object type (InstanceBuilder) to YAML parsing.
+    """
+    def __init__(self, yaml_name, instance_builder, requires_ops=(1,0),
+                 requires_cli=(0,3)):
+        self.yaml_name = yaml_name
+        self.instance_builder = instance_builder
+        super().__init__(requires_ops, requires_cli)
+
+
 class CLIPluginLoader(object):
     """Abstract object for CLI plugins
 

--- a/paths_cli/plugin_management.py
+++ b/paths_cli/plugin_management.py
@@ -60,16 +60,20 @@ class OPSCommandPlugin(Plugin):
 class CLIPluginLoader(object):
     """Abstract object for CLI plugins
 
-    The overall approach involves 5 steps, each of which can be overridden:
+    The overall approach involves 3 steps:
 
-    1. Find candidate plugins (which must be Python modules)
+    1. Find modules in the relevant locations
     2. Load the namespaces associated into a dict (nsdict)
-    3. Based on those namespaces, validate that the module *is* a plugin
-    4. Get the associated command name
-    5. Return an OPSPlugin object for each plugin
+    3. Find all objects in those namespaces that are plugins
 
-    Details on steps 1, 2, and 4 differ based on whether this is a
-    filesystem-based plugin or a namespace-based plugin.
+    Additionally, we attach metadata about where the plugin was found and
+    what mechamism it was loaded with.
+
+    Details on steps 1 and 2 differ based on whether this is a
+    filesystem-based plugin or a namespace-based plugin, and details on step
+    3 can depend on the specific instance created. By default, it looks for
+    instances of :class:`.Plugin` (given as ``plugin_class``) but the
+    ``isinstance`` check can be overridden in subclasses.
     """
     def __init__(self, plugin_type, search_path, plugin_class=Plugin):
         self.plugin_type = plugin_type

--- a/paths_cli/tests/null_command.py
+++ b/paths_cli/tests/null_command.py
@@ -1,7 +1,7 @@
 import logging
 import click
 
-from paths_cli.plugin_management import FilePluginLoader, OPSPlugin
+from paths_cli.plugin_management import FilePluginLoader, OPSCommandPlugin
 
 @click.command(
     'null-command',
@@ -11,17 +11,17 @@ def null_command():
     logger = logging.getLogger(__name__)
     logger.info("Running null command")
 
-CLI = null_command
-SECTION = "Workflow"
+PLUGIN = OPSCommandPlugin(
+    command=null_command,
+    section="Workflow"
+)
 
 class NullCommandContext(object):
     """Context that registers/deregisters the null command (for tests)"""
     def __init__(self, cli):
-        self.plugin = OPSPlugin(name="null-command",
-                                location=__file__,
-                                func=CLI,
-                                section=SECTION,
-                                plugin_type="file")
+        self.plugin = PLUGIN
+        self.plugin.attach_metadata(location=__file__,
+                                    plugin_type='file')
 
         cli._register_plugin(self.plugin)
         self.cli = cli

--- a/paths_cli/tests/test_cli.py
+++ b/paths_cli/tests/test_cli.py
@@ -3,7 +3,6 @@ from unittest.mock import patch, MagicMock
 from click.testing import CliRunner
 
 from paths_cli.cli import *
-# from paths_cli.plugin_management import OPSPlugin
 from .null_command import NullCommandContext
 
 

--- a/paths_cli/tests/test_cli.py
+++ b/paths_cli/tests/test_cli.py
@@ -3,31 +3,40 @@ from unittest.mock import patch, MagicMock
 from click.testing import CliRunner
 
 from paths_cli.cli import *
-from paths_cli.plugin_management import OPSPlugin
+# from paths_cli.plugin_management import OPSPlugin
 from .null_command import NullCommandContext
 
 
 class TestOpenPathSamplingCLI(object):
     def setup(self):
-        def make_mock(name, helpless=False):
-            mock = MagicMock(return_value=name)
+        def make_mock(name, helpless=False, return_val=None):
+            if return_val is None:
+                return_val = name
+            mock = MagicMock(return_value=return_val)
+            mock.name = name
             if helpless:
                 mock.short_help = None
             else:
                 mock.short_help = name + " help"
             return mock
 
+        foo_plugin = OPSCommandPlugin(
+            command=make_mock('foo'),
+            section="Simulation"
+        )
+        foo_plugin.attach_metadata(location="foo.py",
+                                   plugin_type='file')
+        foobar_plugin = OPSCommandPlugin(
+            command=make_mock('foo-bar', helpless=True,
+                              return_val='foobar'),
+            section="Miscellaneous"
+        )
+        foobar_plugin.attach_metadata(location='foo_bar.py',
+                                      plugin_type='file')
+
         self.plugin_dict = {
-            'foo': OPSPlugin(name='foo',
-                             location='foo.py',
-                             func=make_mock('foo'),
-                             section='Simulation',
-                             plugin_type='file'),
-            'foo-bar': OPSPlugin(name='foo-bar',
-                                 location='foo_bar.py',
-                                 func=make_mock('foobar', helpless=True),
-                                 section='Miscellaneous',
-                                 plugin_type="file")
+            'foo': foo_plugin,
+            'foo-bar': foobar_plugin,
         }
         self.plugins = list(self.plugin_dict.values())
         self.cli = OpenPathSamplingCLI()

--- a/paths_cli/tests/test_plugin_management.py
+++ b/paths_cli/tests/test_plugin_management.py
@@ -10,6 +10,12 @@ from paths_cli.plugin_management import *
 # need to check that CLI is assigned to correct type
 import click
 
+def test_ops_plugin():
+    plugin = OPSPlugin(requires_ops=(1,2), requires_cli=(0,4))
+    assert plugin.requires_ops == (1, 2)
+    assert plugin.requires_cli == (0, 4)
+    assert plugin.requires_lib == (1, 2)
+
 class PluginLoaderTest(object):
     def setup(self):
         self.expected_section = {'pathsampling': "Simulation",

--- a/paths_cli/tests/test_plugin_management.py
+++ b/paths_cli/tests/test_plugin_management.py
@@ -61,8 +61,9 @@ class PluginLoaderTest(object):
     def test_make_nsdict(self, command):
         candidate = self._make_candidate(command)
         nsdict = self.loader._make_nsdict(candidate)
-        assert nsdict['SECTION'] == self.expected_section[command]
-        assert isinstance(nsdict['CLI'], click.Command)
+        plugin = nsdict['PLUGIN']
+        assert plugin.section == self.expected_section[command]
+        assert isinstance(plugin.command, click.Command)
 
     @pytest.mark.parametrize('command', ['pathsampling', 'contents'])
     def test_call(self, command):
@@ -82,7 +83,7 @@ class TestFilePluginLoader(PluginLoaderTest):
         # use our own commands dir as a file-based plugin
         cmds_init = pathlib.Path(paths_cli.commands.__file__).resolve()
         self.commands_dir = cmds_init.parent
-        self.loader = FilePluginLoader(self.commands_dir)
+        self.loader = FilePluginLoader(self.commands_dir, OPSCommandPlugin)
         self.plugin_type = 'file'
 
     def _make_candidate(self, command):
@@ -99,7 +100,7 @@ class TestNamespacePluginLoader(PluginLoaderTest):
     def setup(self):
         super().setup()
         self.namespace = "paths_cli.commands"
-        self.loader = NamespacePluginLoader(self.namespace)
+        self.loader = NamespacePluginLoader(self.namespace, OPSCommandPlugin)
         self.plugin_type = 'namespace'
 
     def _make_candidate(self, command):
@@ -107,7 +108,7 @@ class TestNamespacePluginLoader(PluginLoaderTest):
         return importlib.import_module(name)
 
     def test_get_command_name(self):
-        loader = NamespacePluginLoader('foo.bar')
+        loader = NamespacePluginLoader('foo.bar', OPSCommandPlugin)
         candidate = MagicMock(__name__="foo.bar.baz_qux")
         expected = "baz-qux"
         assert loader._get_command_name(candidate) == expected


### PR DESCRIPTION
This PR introduces a new plugin infrastructure for the OPS CLI. This is a major API break, and all externally-developed plugins will need to update for it.

Fortunately, the update procedure is simple: Previously, plugins had to be one per module (file), and the modules needed to define the variables `CLI` (to label the command), `SECTION` (the help section to use), and optionally `REQUIRES_OPS` (the minimum OPS version).

The new plugins require importing `paths_cli.OPSCommandPlugin`, and then creating an `OPSCommandPlugin` instance, which takes the required variables `command` and `section`, and the optional variables `requires_ops` and `requires_cli` (which defines the minimum CLI version.) Note that this `OPSCommandPlugin` instance must be assigned to a name in the module (it needs to be listed in the module's `vars`.) I happen to choose the name `PLUGIN` in the examples, but the specific name doesn't matter.

For examples on how to do the update, see changes to files in the `commands` directory in this PR.

The major advantages of the new plugin system are:

1. It is possible to define more than one plugin in a given file.
2. The new approach is not narrowly focused on subcommands of the CLI. The plugin infrastructure could be used for plugins for other tools, such as in #41 or in #43.

For developers who want to support for OPS CLI 0.3 (where this will be included) and earlier versions, the two methods can be used simultaneously, but both methods must be included in order for plugins to work with all versions of the CLI (i.e., unmodified old plugins will not load with new versions of the CLI).

Tasks:

- [x] Code
- [x] Tests
- [x] Migrate commands
- [x] Migrate miscellaneous (examples for writing plugins; plugins used in testing)
- [x] Update docstrings on plugin management tools
- [x] Update docs on writing plugins
