### PR TITLE
Updates for OpenMM 7.6

### DIFF
--- a/paths_cli/tests/wizard/conftest.py
+++ b/paths_cli/tests/wizard/conftest.py
@@ -3,6 +3,7 @@ import pytest
 import openpathsampling as paths
 import mdtraj as md
 
+# should be able to remove this try block when we drop OpenMM < 7.6
 try:
     import openmm as mm
     from openmm import unit as u
@@ -22,8 +23,9 @@ def ad_openmm(tmpdir):
     """
     Provide directory with files to start alanine depeptide sim in OpenMM
     """
+    # switch back to importorskip when we drop OpenMM < 7.6
     if not HAS_OPENMM:
-        pytest.skip()
+        pytest.skip("could not import openmm")
     # mm = pytest.importorskip('simtk.openmm')
     # u = pytest.importorskip('simtk.unit')
     openmmtools = pytest.importorskip('openmmtools')

--- a/paths_cli/tests/wizard/conftest.py
+++ b/paths_cli/tests/wizard/conftest.py
@@ -3,13 +3,29 @@ import pytest
 import openpathsampling as paths
 import mdtraj as md
 
+try:
+    import openmm as mm
+    from openmm import unit as u
+except ImportError:
+    try:
+        from simtk import openmm as mm
+        from simtk import unit as u
+    except ImportError:
+        HAS_OPENMM = False
+    else: # -no-cov-
+        HAS_OPENMM = True
+else:
+    HAS_OPENMM = True
+
 @pytest.fixture
 def ad_openmm(tmpdir):
     """
     Provide directory with files to start alanine depeptide sim in OpenMM
     """
-    mm = pytest.importorskip('simtk.openmm')
-    u = pytest.importorskip('simtk.unit')
+    if not HAS_OPENMM:
+        pytest.skip()
+    # mm = pytest.importorskip('simtk.openmm')
+    # u = pytest.importorskip('simtk.unit')
     openmmtools = pytest.importorskip('openmmtools')
     md = pytest.importorskip('mdtraj')
     testsystem = openmmtools.testsystems.AlanineDipeptideVacuum()

--- a/paths_cli/tests/wizard/test_openmm.py
+++ b/paths_cli/tests/wizard/test_openmm.py
@@ -8,12 +8,26 @@ from paths_cli.wizard.openmm import (
     _load_openmm_xml, _load_topology, openmm, OPENMM_SERIALIZATION_URL
 )
 
+try:
+    import openmm as mm
+except ImportError:
+    try:
+        from simtk import openmm as mm
+    except ImportError:
+        HAS_OPENMM = False
+    else:
+        HAS_OPENMM = True  # -no-cov-
+else:
+    HAS_OPENMM = True
+
 def test_helper_url():
     assert_url(OPENMM_SERIALIZATION_URL)
 
 @pytest.mark.parametrize('obj_type', ['system', 'integrator', 'foo'])
 def test_load_openmm_xml(ad_openmm, obj_type):
-    mm = pytest.importorskip('simtk.openmm')
+    if not HAS_OPENMM:
+        pytest.skip()
+    # mm = pytest.importorskip("simtk.openmm")
     filename = f"{obj_type}.xml"
     inputs = [filename]
     expected_count = 1

--- a/paths_cli/tests/wizard/test_openmm.py
+++ b/paths_cli/tests/wizard/test_openmm.py
@@ -8,6 +8,7 @@ from paths_cli.wizard.openmm import (
     _load_openmm_xml, _load_topology, openmm, OPENMM_SERIALIZATION_URL
 )
 
+# should be able to remove this try block when we drop OpenMM < 7.6
 try:
     import openmm as mm
 except ImportError:
@@ -25,8 +26,9 @@ def test_helper_url():
 
 @pytest.mark.parametrize('obj_type', ['system', 'integrator', 'foo'])
 def test_load_openmm_xml(ad_openmm, obj_type):
+    # switch back to importorskip when we drop OpenMM < 7.6
     if not HAS_OPENMM:
-        pytest.skip()
+        pytest.skip("could not import openmm")
     # mm = pytest.importorskip("simtk.openmm")
     filename = f"{obj_type}.xml"
     inputs = [filename]

--- a/paths_cli/wizard/openmm.py
+++ b/paths_cli/wizard/openmm.py
@@ -10,7 +10,7 @@ else:
 
 OPENMM_SERIALIZATION_URL=(
     "http://docs.openmm.org/latest/api-python/generated/"
-    "simtk.openmm.openmm.XmlSerializer.html"
+    "openmm.openmm.XmlSerializer.html"
 )
 
 def _openmm_serialization_helper(wizard, user_input):  # no-cov

--- a/paths_cli/wizard/openmm.py
+++ b/paths_cli/wizard/openmm.py
@@ -1,10 +1,14 @@
 from paths_cli.wizard.errors import FILE_LOADING_ERROR_MSG, not_installed
 from paths_cli.wizard.core import get_object
 try:
-    from simtk import openmm as mm
-    import mdtraj as md
+    import openmm as mm
 except ImportError:
-    HAS_OPENMM = False
+    try:
+        from simtk import openmm as mm
+    except ImportError:
+        HAS_OPENMM = False
+    else:  # -no-cov-
+      HAS_OPENMM = True
 else:
     HAS_OPENMM = True
 

--- a/paths_cli/wizard/openmm.py
+++ b/paths_cli/wizard/openmm.py
@@ -1,5 +1,7 @@
 from paths_cli.wizard.errors import FILE_LOADING_ERROR_MSG, not_installed
 from paths_cli.wizard.core import get_object
+
+# should be able to simplify this try block when we drop OpenMM < 7.6
 try:
     import openmm as mm
 except ImportError:


### PR DESCRIPTION
Most significantly, this fixes a test error on the URL [that @sroet suggested I add a test for](https://github.com/openpathsampling/openpathsampling-cli/pull/41#discussion_r676509042) (thanks @sroet!) by removing the `simtk` from the URL. I also went ahead and made it so we preferred new 7.6-style imports everywhere else.