### PR TITLE
Remove nc from descriptions of OPS files

### DIFF
--- a/paths_cli/commands/contents.py
+++ b/paths_cli/commands/contents.py
@@ -22,13 +22,13 @@ NAME_TO_ATTR = {
 
 @click.command(
     'contents',
-    short_help="list named objects from an OPS output file",
+    short_help="list named objects from an OPS storage file",
 )
 @INPUT_FILE.clicked(required=True)
 @click.option('--table', type=str, required=False,
               help="table to show results from")
 def contents(input_file, table):
-    """List the names of named objects in an OPS output file.
+    """List the names of named objects in an OPS storage file.
 
     This is particularly useful when getting ready to use a simulation
     command (i.e., to identify exactly how a state or engine is named.)

--- a/paths_cli/commands/contents.py
+++ b/paths_cli/commands/contents.py
@@ -22,16 +22,16 @@ NAME_TO_ATTR = {
 
 @click.command(
     'contents',
-    short_help="list named objects from an OPS .nc file",
+    short_help="list named objects from an OPS output file",
 )
 @INPUT_FILE.clicked(required=True)
 @click.option('--table', type=str, required=False,
               help="table to show results from")
 def contents(input_file, table):
-    """List the names of named objects in an OPS .nc file.
+    """List the names of named objects in an OPS output file.
 
-    This is particularly useful when getting ready to use one of simulation
-    scripts (i.e., to identify exactly how a state or engine is named.)
+    This is particularly useful when getting ready to use a simulation
+    command (i.e., to identify exactly how a state or engine is named.)
     """
     storage = INPUT_FILE.get(input_file)
     print(storage)

--- a/paths_cli/parameters.py
+++ b/paths_cli/parameters.py
@@ -96,7 +96,7 @@ INPUT_FILE = StorageLoader(
 OUTPUT_FILE = StorageLoader(
     param=Option('-o', '--output-file',
                  type=click.Path(writable=True),
-                 help="output ncfile"),
+                 help="output file"),
     mode='w'
 )
 


### PR DESCRIPTION
Files can also be .db. Change recommended as an aside in https://github.com/openpathsampling/mini-tutorials/issues/5#issuecomment-911562562.