### PR TITLE
switch codecov bash uploader for their github action

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -71,5 +71,4 @@ jobs:
         run: |
           python -c "import paths_cli"
           py.test -vv --cov --cov-report xml:cov.xml
-      - name: "Report coverage"
-        run: bash <(curl -s https://codecov.io/bash)
+      - uses: codecov/codecov-action@v2


### PR DESCRIPTION
[codecov deprecated the bash uploader](https://about.codecov.io/blog/codecov-uploader-deprecation-plan/). They advice people to switch to [their github action workflow](https://github.com/marketplace/actions/codecov). This implements the suggested switch