### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -27,7 +27,6 @@ jobs:
           - 3.9
           - 3.8
           - 3.7
-          - 3.6
         INTEGRATIONS: [""]
         include:
           - CONDA_PY: 3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
     Programming Language :: Python :: 3
 
 [options]
-python_requires = >= 3.6
+python_requires = >= 3.7
 install_requires =
     click
     tqdm


### PR DESCRIPTION
Technically, we could drop this as of June 23, 2020, since we're following NEP 29 here. However, there was no need until I started working on #54, where I want defaults in a `namedtuple` (introduced in Python 3.7).

Not adding Python 3.10 to the test matrix yet because we're waiting on support from our requirements (which, y'know, starts with conda-forge having Python 3.10 available.)