### PR TITLE
pylint/flake8: `paths_cli.compiling`

### DIFF
--- a/paths_cli/compiling/core.py
+++ b/paths_cli/compiling/core.py
@@ -1,13 +1,10 @@
 import json
-import yaml
-
-from collections import namedtuple
-
 import logging
 
-from .errors import InputError
 from paths_cli.utils import import_thing
 from paths_cli.plugin_management import OPSPlugin
+from paths_cli.compiling.errors import InputError
+
 
 def listify(obj):
     listified = False
@@ -16,16 +13,20 @@ def listify(obj):
         listified = True
     return obj, listified
 
+
 def unlistify(obj, listified):
     if listified:
         assert len(obj) == 1
         obj = obj[0]
     return obj
 
+
 REQUIRED_PARAMETER = object()
+
 
 class Parameter:
     SCHEMA = "http://openpathsampling.org/schemas/sim-setup/draft01.json"
+
     def __init__(self, name, loader, *, json_type=None, description=None,
                  default=REQUIRED_PARAMETER, aliases=None):
         if isinstance(json_type, str):
@@ -150,6 +151,7 @@ class InstanceCompilerPlugin(OPSPlugin):
     """
     SCHEMA = "http://openpathsampling.org/schemas/sim-setup/draft01.json"
     category = None
+
     def __init__(self, builder, parameters, name=None, aliases=None,
                  requires_ops=(1, 0), requires_cli=(0, 3)):
         super().__init__(requires_ops, requires_cli)
@@ -239,7 +241,7 @@ class InstanceCompilerPlugin(OPSPlugin):
         ops_dct = self.compile_attrs(dct)
         self.logger.debug("Building...")
         self.logger.debug(ops_dct)
-        obj =  self.builder(**ops_dct)
+        obj = self.builder(**ops_dct)
         self.logger.debug(obj)
         return obj
 
@@ -260,7 +262,7 @@ class CategoryCompiler:
         self.logger.debug(f"Looking for '{name}'")
         try:
             return self.named_objs[name]
-        except KeyError as e:
+        except KeyError:
             raise InputError.unknown_name(self.label, name)
 
     def _compile_dict(self, dct):

--- a/paths_cli/compiling/cvs.py
+++ b/paths_cli/compiling/cvs.py
@@ -1,10 +1,7 @@
-import os
-import importlib
-
-from .core import Parameter, Builder
-from .tools import custom_eval
-from .topology import build_topology
-from .errors import InputError
+from paths_cli.compiling.core import Parameter, Builder
+from paths_cli.compiling.tools import custom_eval
+from paths_cli.compiling.topology import build_topology
+from paths_cli.compiling.errors import InputError
 from paths_cli.utils import import_thing
 from paths_cli.compiling.plugins import CVCompilerPlugin, CategoryPlugin
 
@@ -20,6 +17,7 @@ class AllowedPackageHandler:
             raise InputError(f"No function called {source} in {self.package}")
         # on ImportError, we leave the error unchanged
         return func
+
 
 def _cv_kwargs_remapper(dct):
     kwargs = dct.pop('kwargs', {})

--- a/paths_cli/compiling/engines.py
+++ b/paths_cli/compiling/engines.py
@@ -1,8 +1,9 @@
-from .topology import build_topology
-from .core import Builder
+from paths_cli.compiling.topology import build_topology
+from paths_cli.compiling.core import Builder
 from paths_cli.compiling.core import Parameter
-from .tools import custom_eval_int_strict_pos
+from paths_cli.compiling.tools import custom_eval_int_strict_pos
 from paths_cli.compiling.plugins import EngineCompilerPlugin, CategoryPlugin
+
 
 def load_openmm_xml(filename):
     from paths_cli.compat.openmm import HAS_OPENMM, mm
@@ -13,6 +14,7 @@ def load_openmm_xml(filename):
         obj = mm.XmlSerializer.deserialize(f.read())
 
     return obj
+
 
 def _openmm_options(dct):
     n_steps_per_frame = dct.pop('n_steps_per_frame')

--- a/paths_cli/compiling/errors.py
+++ b/paths_cli/compiling/errors.py
@@ -9,4 +9,3 @@ class InputError(Exception):
     @classmethod
     def unknown_name(cls, type_name, name):
         return cls(f"Unable to find object named {name} in {type_name}")
-

--- a/paths_cli/compiling/networks.py
+++ b/paths_cli/compiling/networks.py
@@ -10,11 +10,12 @@ build_interface_set = InstanceCompilerPlugin(
     parameters=[
         Parameter('cv', compiler_for('cv'), description="the collective "
                   "variable for this interface set"),
-        Parameter('minvals', custom_eval), # TODO fill in JSON types
-        Parameter('maxvals', custom_eval), # TODO fill in JSON types
+        Parameter('minvals', custom_eval),  # TODO fill in JSON types
+        Parameter('maxvals', custom_eval),  # TODO fill in JSON types
     ],
     name='interface-set'
 )
+
 
 def mistis_trans_info(dct):
     dct = dct.copy()
@@ -31,6 +32,7 @@ def mistis_trans_info(dct):
     dct['trans_info'] = trans_info
     return dct
 
+
 def tis_trans_info(dct):
     # remap TIS into MISTIS format
     dct = dct.copy()
@@ -41,6 +43,7 @@ def tis_trans_info(dct):
                            'final_state': final_state,
                            'interfaces': interface_set}]
     return mistis_trans_info(dct)
+
 
 TPS_NETWORK_PLUGIN = NetworkCompilerPlugin(
     builder=Builder('openpathsampling.TPSNetwork'),
@@ -59,6 +62,7 @@ MISTIS_NETWORK_PLUGIN = NetworkCompilerPlugin(
     builder=Builder('openpathsampling.MISTISNetwork'),
     name='mistis'
 )
+
 
 TIS_NETWORK_PLUGIN = NetworkCompilerPlugin(
     builder=Builder('openpathsampling.MISTISNetwork'),

--- a/paths_cli/compiling/plugins.py
+++ b/paths_cli/compiling/plugins.py
@@ -1,12 +1,13 @@
 from paths_cli.compiling.core import InstanceCompilerPlugin
 from paths_cli.plugin_management import OPSPlugin
 
+
 class CategoryPlugin(OPSPlugin):
     """
     Category plugins only need to be made for top-level
     """
     def __init__(self, plugin_class, aliases=None, requires_ops=(1, 0),
-                 requires_cli=(0,4)):
+                 requires_cli=(0, 3)):
         super().__init__(requires_ops, requires_cli)
         self.plugin_class = plugin_class
         if aliases is None:
@@ -25,17 +26,22 @@ class CategoryPlugin(OPSPlugin):
 class EngineCompilerPlugin(InstanceCompilerPlugin):
     category = 'engine'
 
+
 class CVCompilerPlugin(InstanceCompilerPlugin):
     category = 'cv'
+
 
 class VolumeCompilerPlugin(InstanceCompilerPlugin):
     category = 'volume'
 
+
 class NetworkCompilerPlugin(InstanceCompilerPlugin):
     category = 'network'
 
+
 class SchemeCompilerPlugin(InstanceCompilerPlugin):
     category = 'scheme'
+
 
 class StrategyCompilerPlugin(InstanceCompilerPlugin):
     category = 'strategy'

--- a/paths_cli/compiling/root_compiler.py
+++ b/paths_cli/compiling/root_compiler.py
@@ -6,6 +6,7 @@ from paths_cli.compiling.plugins import CategoryPlugin
 import logging
 logger = logging.getLogger(__name__)
 
+
 class CategoryCompilerRegistrationError(Exception):
     pass
 
@@ -22,6 +23,7 @@ _DEFAULT_COMPILE_ORDER = [
 
 COMPILE_ORDER = _DEFAULT_COMPILE_ORDER.copy()
 
+
 def clean_input_key(key):
     # TODO: move this to core
     """
@@ -34,11 +36,13 @@ def clean_input_key(key):
     key = key.replace("-", "_")
     return key
 
+
 ### Managing known compilers and aliases to the known compilers ############
 
 _COMPILERS = {}  # mapping: {canonical_name: CategoryCompiler}
 _ALIASES = {}  # mapping: {alias: canonical_name}
 # NOTE: _ALIASES does *not* include self-mapping of the canonical names
+
 
 def _canonical_name(alias):
     """Take an alias or a compiler name and return the compiler name
@@ -50,6 +54,7 @@ def _canonical_name(alias):
     alias_to_canonical = _ALIASES.copy()
     alias_to_canonical.update({pname: pname for pname in _COMPILERS})
     return alias_to_canonical.get(alias, None)
+
 
 def _get_compiler(category):
     """
@@ -69,6 +74,7 @@ def _get_compiler(category):
         _COMPILERS[category] = CategoryCompiler(None, category)
     return _COMPILERS[canonical_name]
 
+
 def _register_compiler_plugin(plugin):
     DUPLICATE_ERROR = CategoryCompilerRegistrationError(
         f"The category '{plugin.name}' has been reserved by another plugin"
@@ -87,7 +93,7 @@ def _register_compiler_plugin(plugin):
 
 
 ### Handling delayed loading of compilers ##################################
-#
+
 # Many objects need to use compilers to create their input parameters. In
 # order for them to be able to access dynamically-loaded plugins, we delay
 # the loading of the compiler by using a proxy object.
@@ -110,6 +116,7 @@ class _CategoryCompilerProxy:
 
     def __call__(self, dct):
         return self._proxy(dct)
+
 
 def compiler_for(category):
     """Delayed compiler calling.
@@ -142,10 +149,12 @@ def _get_registration_names(plugin):
             found_names.add(name)
     return ordered_names
 
+
 def _register_builder_plugin(plugin):
     compiler = _get_compiler(plugin.category)
     for name in _get_registration_names(plugin):
         compiler.register_builder(plugin, name)
+
 
 def register_plugins(plugins):
     builders = []
@@ -161,6 +170,7 @@ def register_plugins(plugins):
 
     for plugin in builders:
         _register_builder_plugin(plugin)
+
 
 ### Performing the compiling of user input #################################
 
@@ -178,6 +188,7 @@ def _sort_user_categories(user_categories):
         key=lambda x: COMPILE_ORDER.index(user_to_canonical[x])
     )
     return sorted_keys
+
 
 def do_compile(dct):
     """Main function for compiling user input to objects.

--- a/paths_cli/compiling/schemes.py
+++ b/paths_cli/compiling/schemes.py
@@ -26,6 +26,7 @@ SPRING_SHOOTING_PLUGIN = SchemeCompilerPlugin(
     name='spring-shooting',
 )
 
+
 class BuildSchemeStrategy:
     def __init__(self, scheme_class, default_global_strategy):
         self.scheme_class = scheme_class

--- a/paths_cli/compiling/shooting.py
+++ b/paths_cli/compiling/shooting.py
@@ -4,17 +4,20 @@ from paths_cli.compiling.core import (
 from paths_cli.compiling.root_compiler import compiler_for
 from paths_cli.compiling.tools import custom_eval
 
+
 build_uniform_selector = InstanceCompilerPlugin(
     builder=Builder('openpathsampling.UniformSelector'),
     parameters=[],
     name='uniform',
 )
 
+
 def _remapping_gaussian_stddev(dct):
     dct['alpha'] = 0.5 / dct.pop('stddev')**2
     dct['collectivevariable'] = dct.pop('cv')
     dct['l_0'] = dct.pop('mean')
     return dct
+
 
 build_gaussian_selector = InstanceCompilerPlugin(
     builder=Builder('openpathsampling.GaussianBiasSelector',
@@ -26,6 +29,7 @@ build_gaussian_selector = InstanceCompilerPlugin(
     ],
     name='gaussian',
 )
+
 
 shooting_selector_compiler = CategoryCompiler(
     type_dispatch={

--- a/paths_cli/compiling/strategies.py
+++ b/paths_cli/compiling/strategies.py
@@ -5,17 +5,19 @@ from paths_cli.compiling.plugins import (
 )
 from paths_cli.compiling.root_compiler import compiler_for
 
+
 def _strategy_name(class_name):
     return f"openpathsampling.strategies.{class_name}"
+
 
 def _group_parameter(group_name):
     return Parameter('group', str, default=group_name,
                      description="the group name for these movers")
 
+
 # TODO: maybe this moves into shooting once we have the metadata?
 SP_SELECTOR_PARAMETER = Parameter('selector', shooting_selector_compiler,
                                   default=None)
-
 ENGINE_PARAMETER = Parameter('engine', compiler_for('engine'),
                              description="the engine for moves of this "
                              "type")
@@ -39,6 +41,7 @@ ONE_WAY_SHOOTING_STRATEGY_PLUGIN = StrategyCompilerPlugin(
     name='one-way-shooting',
 )
 build_one_way_shooting_strategy = ONE_WAY_SHOOTING_STRATEGY_PLUGIN
+
 # build_two_way_shooting_strategy = StrategyCompilerPlugin(
 #     builder=Builder(_strategy_name("TwoWayShootingStrategy")),
 #     parameters = [

--- a/paths_cli/compiling/tools.py
+++ b/paths_cli/compiling/tools.py
@@ -1,5 +1,6 @@
 import numpy as np
-from .errors import InputError
+from paths_cli.compiling.errors import InputError
+
 
 def custom_eval(obj, named_objs=None):
     """Parse user input to allow simple math.
@@ -19,9 +20,11 @@ def custom_eval(obj, named_objs=None):
     }
     return eval(string, namespace)
 
+
 def custom_eval_int(obj, named_objs=None):
     val = custom_eval(obj, named_objs)
     return int(val)
+
 
 def custom_eval_int_strict_pos(obj, named_objs=None):
     val = custom_eval_int(obj, named_objs)
@@ -32,6 +35,7 @@ def custom_eval_int_strict_pos(obj, named_objs=None):
 
 class UnknownAtomsError(RuntimeError):
     pass
+
 
 def mdtraj_parse_atomlist(inp_str, n_atoms, topology=None):
     """
@@ -47,7 +51,7 @@ def mdtraj_parse_atomlist(inp_str, n_atoms, topology=None):
         raise TypeError("Input is not integers")
     if arr.shape != (1, n_atoms):
         # try to clean it up
-        if len(arr.shape) == 1 and arr.shape[0] ==  n_atoms:
+        if len(arr.shape) == 1 and arr.shape[0] == n_atoms:
             arr.shape = (1, n_atoms)
         else:
             raise TypeError(f"Invalid input. Requires {n_atoms} "

--- a/paths_cli/compiling/topology.py
+++ b/paths_cli/compiling/topology.py
@@ -1,6 +1,7 @@
 import os
-from .errors import InputError
+from paths_cli.compiling.errors import InputError
 from paths_cli.compiling.root_compiler import compiler_for
+
 
 def get_topology_from_engine(dct):
     """If given the name of an engine, use that engine's topology"""
@@ -8,6 +9,8 @@ def get_topology_from_engine(dct):
     if dct in engine_compiler.named_objs:
         engine = engine_compiler.named_objs[dct]
         return getattr(engine, 'topology', None)
+    return None
+
 
 def get_topology_from_file(dct):
     """If given the name of a file, use that to create the topology"""
@@ -16,6 +19,7 @@ def get_topology_from_file(dct):
         import openpathsampling as paths
         trj = md.load(dct)
         return paths.engines.MDTrajTopology(trj.topology)
+    return None
 
 
 class MultiStrategyBuilder:
@@ -34,6 +38,7 @@ class MultiStrategyBuilder:
 
         # only get here if we failed
         raise InputError.invalid_input(dct, self.label)
+
 
 build_topology = MultiStrategyBuilder(
     [get_topology_from_file, get_topology_from_engine],

--- a/paths_cli/compiling/volumes.py
+++ b/paths_cli/compiling/volumes.py
@@ -1,10 +1,11 @@
 import operator
 import functools
 
-from .core import Parameter
-from .tools import custom_eval
+from paths_cli.compiling.core import Parameter
+from paths_cli.compiling.tools import custom_eval
 from paths_cli.compiling.plugins import VolumeCompilerPlugin, CategoryPlugin
 from paths_cli.compiling.root_compiler import compiler_for
+
 
 # TODO: extra function for volumes should not be necessary as of OPS 2.0
 def cv_volume_build_func(**dct):
@@ -17,6 +18,7 @@ def cv_volume_build_func(**dct):
     dct['collectivevariable'] = dct.pop('cv')
     # TODO: wrap this with some logging
     return builder(**dct)
+
 
 CV_VOLUME_PLUGIN = VolumeCompilerPlugin(
     builder=cv_volume_build_func,
@@ -39,6 +41,7 @@ VOL_ARRAY_TYPE = {
     'items': {"$ref": "#/definitions/volume_type"}
 }
 
+
 INTERSECTION_VOLUME_PLUGIN = VolumeCompilerPlugin(
     builder=lambda subvolumes: functools.reduce(operator.__and__,
                                                 subvolumes),
@@ -52,6 +55,7 @@ INTERSECTION_VOLUME_PLUGIN = VolumeCompilerPlugin(
 
 build_intersection_volume = INTERSECTION_VOLUME_PLUGIN
 
+
 UNION_VOLUME_PLUGIN = VolumeCompilerPlugin(
     builder=lambda subvolumes: functools.reduce(operator.__or__,
                                                 subvolumes),
@@ -64,6 +68,7 @@ UNION_VOLUME_PLUGIN = VolumeCompilerPlugin(
 )
 
 build_union_volume = UNION_VOLUME_PLUGIN
+
 
 VOLUME_COMPILER = CategoryPlugin(VolumeCompilerPlugin, aliases=['state',
                                                                 'states'])


### PR DESCRIPTION
Now that my in-editor linter is working again, I went over the code in the `compiling` subpackage and cleaned up most of the things that registered as errors in `pylint` and `flake8`.

I also used this as an excuse to start writing up a more detailed style guide for OpenPathSampling projects. I plan to put it in the main OPS developer docs as part of OPS 2.0 (it is Python 3 specific). The document is basically a list of "here are common cases where we allow exceptions to flake8/pylint errors and warnings" (basically, some guidelines as to when, IMHO, consistency becomes foolish consistency.)

Doc being developed in a gist: https://gist.github.com/dwhswenson/1361b849866af98e7f8e6599810670b2

EDIT: also includes an incorrect version requirement in `CategoryPlugin`, which will be part of v0.3 (not v0.4 as I originally thought).