### PR TITLE
Preserve plugin load order with `OrderedSet`

### DIFF
--- a/paths_cli/tests/test_utils.py
+++ b/paths_cli/tests/test_utils.py
@@ -7,6 +7,12 @@ class TestOrderedSet:
     def test_len(self):
         assert len(self.set) == 4
 
+    def test_empty(self):
+        ordered = OrderedSet()
+        assert len(ordered) == 0
+        for _ in ordered:
+            raise RuntimeError("This should not happen")
+
     def test_order(self):
         for truth, beauty in zip("abcd", self.set):
             assert truth == beauty

--- a/paths_cli/tests/test_utils.py
+++ b/paths_cli/tests/test_utils.py
@@ -26,6 +26,7 @@ class TestOrderedSet:
     def test_contains(self):
         assert 'a' in self.set
         assert not 'q' in self.set
+        assert 'q' not in self.set
 
     def test_discard(self):
         self.set.discard('a')

--- a/paths_cli/tests/test_utils.py
+++ b/paths_cli/tests/test_utils.py
@@ -1,0 +1,33 @@
+from paths_cli.utils import *
+
+class TestOrderedSet:
+    def setup(self):
+        self.set = OrderedSet(['a', 'b', 'a', 'c', 'd', 'c', 'd'])
+
+    def test_len(self):
+        assert len(self.set) == 4
+
+    def test_order(self):
+        for truth, beauty in zip("abcd", self.set):
+            assert truth == beauty
+
+    def test_add_existing(self):
+        assert len(self.set) == 4
+        self.set.add('a')
+        assert len(self.set) == 4
+        assert list(self.set) == ['a', 'b', 'c', 'd']
+
+    def test_contains(self):
+        assert 'a' in self.set
+        assert not 'q' in self.set
+
+    def test_discard(self):
+        self.set.discard('a')
+        assert list(self.set) == ['b', 'c', 'd']
+
+    def test_discard_add_order(self):
+        assert list(self.set) == ['a', 'b', 'c', 'd']
+        self.set.discard('a')
+        self.set.add('a')
+        assert list(self.set) == ['b', 'c', 'd', 'a']
+


### PR DESCRIPTION
As mentioned in #57, the Wizard would benefit from plugins always loading in the same order. Without this, the order of category plugins located in the same file tended to be random. For example, the choices of CV types (Distance, Angle, Dihedral, etc) were not consistent between different runs of the wizard. This also seemed to be the case with command plugins: the order they were listed in `--help` was not retained.

Here I replace the `set` used previously with a custom-written `OrderedSet` class. This seems to have fixed these consistency issues.