### PR TITLE
Wizard pauses

### DIFF
--- a/paths_cli/tests/wizard/conftest.py
+++ b/paths_cli/tests/wizard/conftest.py
@@ -5,6 +5,15 @@ import mdtraj as md
 
 from paths_cli.compat.openmm import HAS_OPENMM, mm, unit
 
+from paths_cli.wizard import pause
+
+
+@pytest.fixture(autouse=True, scope='session')
+def pause_style_testing():
+    pause.set_pause_style('testing')
+    yield
+
+
 # TODO: this isn't wizard-specific, and should be moved somwhere more
 # generally useful (like, oh, maybe openpathsampling.tests.fixtures?)
 @pytest.fixture

--- a/paths_cli/tests/wizard/mock_wizard.py
+++ b/paths_cli/tests/wizard/mock_wizard.py
@@ -37,6 +37,10 @@ class MockConsole:
         self.log.append(content + " " + user_input)
         return user_input
 
+    def draw_hline(self):
+        # we don't even bother for the mock console
+        pass
+
     @property
     def log_text(self):
         return "\n".join(self.log)

--- a/paths_cli/tests/wizard/test_pause.py
+++ b/paths_cli/tests/wizard/test_pause.py
@@ -4,6 +4,11 @@ from paths_cli.tests.wizard.mock_wizard import mock_wizard
 
 from paths_cli.wizard.pause import *
 
+@pytest.fixture(autouse=True, scope="module")
+def use_default_pause_style():
+    with pause_style('default'):
+        yield
+
 
 def test_get_pause_style():
     default_style = PAUSE_STYLES['default']

--- a/paths_cli/tests/wizard/test_pause.py
+++ b/paths_cli/tests/wizard/test_pause.py
@@ -1,0 +1,67 @@
+import pytest
+import time
+from paths_cli.tests.wizard.mock_wizard import mock_wizard
+
+from paths_cli.wizard.pause import *
+
+
+def test_get_pause_style():
+    default_style = PAUSE_STYLES['default']
+    assert get_pause_style() == default_style
+
+
+@pytest.mark.parametrize('input_type', ['string', 'tuple', 'PauseStyle'])
+def test_set_pause_style(input_type):
+    # check that we have the default settings
+    default_style = PAUSE_STYLES['default']
+    test_style = PAUSE_STYLES['testing']
+    input_val = {
+        'string': 'testing',
+        'tuple': tuple(test_style),
+        'PauseStyle': PauseStyle(*test_style)
+    }[input_type]
+    assert input_val is not test_style  # always a different object
+    assert get_pause_style() == default_style
+    set_pause_style(input_val)
+    assert get_pause_style() != default_style
+    assert get_pause_style() == test_style
+    set_pause_style('default')  # explicitly reset default
+
+
+def test_set_pause_bad_name():
+    with pytest.raises(RuntimeError, match="Unknown pause style"):
+        set_pause_style('foo')
+
+    # ensure we didn't break anything for later tests
+    assert get_pause_style() == PAUSE_STYLES['default']
+
+
+def test_pause_style_context():
+    assert get_pause_style() == PAUSE_STYLES['default']
+    with pause_style('testing'):
+        assert get_pause_style() == PAUSE_STYLES['testing']
+    assert get_pause_style() == PAUSE_STYLES['default']
+
+
+def _run_pause_test(func):
+    test_style = PAUSE_STYLES['testing']
+    expected = getattr(test_style, func.__name__)
+    wiz = mock_wizard([])
+    with pause_style(test_style):
+        start = time.time()
+        func(wiz)
+        duration = time.time() - start
+    assert expected <= duration < 1.1 * duration
+    return wiz
+
+
+def test_short():
+    _ = _run_pause_test(short)
+
+
+def test_long():
+    _ = _run_pause_test(long)
+
+
+def test_section():
+    wiz = _run_pause_test(section)

--- a/paths_cli/tests/wizard/test_volumes.py
+++ b/paths_cli/tests/wizard/test_volumes.py
@@ -9,12 +9,12 @@ from paths_cli.wizard.volumes import (
     volume_ask
 )
 
-
 import openpathsampling as paths
 from openpathsampling.experimental.storage.collective_variables import \
         CoordinateFunctionCV
 
 from openpathsampling.tests.test_helpers import make_1d_traj
+
 
 def _wrap(x, period_min, period_max):
     # used in testing periodic CVs

--- a/paths_cli/wizard/pause.py
+++ b/paths_cli/wizard/pause.py
@@ -6,7 +6,7 @@ PauseStyle = namedtuple("PauseStyle", ['short', 'long', 'section'])
 
 PAUSE_STYLES = {
     'testing': PauseStyle(0.01, 0.03, 0.05),
-    'default': PauseStyle(0.1, 0.5, 0.5),
+    'default': PauseStyle(0.1, 0.5, 0.75),
     'nopause': PauseStyle(0.0, 0.0, 0.0),
 }
 
@@ -59,7 +59,7 @@ def section(wizard):
     """Section break (pause and possible visual cue).
     """
     time.sleep(_PAUSE_STYLE.section)
-    # TODO: have the wizard draw a line?
+    wizard.console.draw_hline()
 
 
 def long(wizard):

--- a/paths_cli/wizard/pause.py
+++ b/paths_cli/wizard/pause.py
@@ -32,7 +32,6 @@ def pause_style(style):
 
 def get_pause_style():
     """Get the current pause style"""
-    global _PAUSE_STYLE
     return _PAUSE_STYLE
 
 

--- a/paths_cli/wizard/pause.py
+++ b/paths_cli/wizard/pause.py
@@ -1,0 +1,72 @@
+import time
+import contextlib
+from collections import namedtuple
+
+PauseStyle = namedtuple("PauseStyle", ['short', 'long', 'section'])
+
+PAUSE_STYLES = {
+    'testing': PauseStyle(0.01, 0.03, 0.05),
+    'default': PauseStyle(0.1, 0.5, 0.5),
+    'nopause': PauseStyle(0.0, 0.0, 0.0),
+}
+
+_PAUSE_STYLE = PAUSE_STYLES['default']
+
+
+@contextlib.contextmanager
+def pause_style(style):
+    """Context manager for pause styles.
+
+    Parameters
+    ----------
+    style : :class:`.PauseStyle`
+        pause style to use within the context
+    """
+    old_style = get_pause_style()
+    try:
+        set_pause_style(style)
+        yield
+    finally:
+        set_pause_style(old_style)
+
+
+def get_pause_style():
+    """Get the current pause style"""
+    global _PAUSE_STYLE
+    return _PAUSE_STYLE
+
+
+def set_pause_style(style):
+    """Set the pause style
+
+    Parameters
+    ----------
+    pause_style : :class:`.PauseStyle` or str
+        pause style to use, can be a string if the style is registered in
+        pause.PAUSE_STYLES
+    """
+    global _PAUSE_STYLE
+    if isinstance(style, str):
+        try:
+            _PAUSE_STYLE = PAUSE_STYLES[style]
+        except KeyError as exc:
+            raise RuntimeError(f"Unknown pause style: '{style}'") from exc
+    else:
+        _PAUSE_STYLE = style
+
+
+def section(wizard):
+    """Section break (pause and possible visual cue).
+    """
+    time.sleep(_PAUSE_STYLE.section)
+    # TODO: have the wizard draw a line?
+
+
+def long(wizard):
+    """Long pause from the wizard"""
+    time.sleep(_PAUSE_STYLE.long)
+
+
+def short(wizard):
+    """Short pause from the wizard"""
+    time.sleep(_PAUSE_STYLE.short)

--- a/paths_cli/wizard/two_state_tps.py
+++ b/paths_cli/wizard/two_state_tps.py
@@ -4,6 +4,7 @@ from paths_cli.wizard.steps import (
     SINGLE_ENGINE_STEP, CVS_STEP, WizardStep
 )
 from paths_cli.wizard.wizard import Wizard
+from paths_cli.wizard import pause
 
 volumes = get_category_wizard('volume')
 from paths_cli.wizard.volumes import _FIRST_STATE, _VOL_DESC
@@ -18,6 +19,7 @@ def two_state_tps(wizard, fixed_length=False):
     ]
     initial_state = volumes(wizard, context={'intro': intro})
     wizard.register(initial_state, 'initial state', 'states')
+    pause.section(wizard)
     intro = [
         "Next let's define your final state.",
         _VOL_DESC

--- a/paths_cli/wizard/volumes.py
+++ b/paths_cli/wizard/volumes.py
@@ -8,16 +8,21 @@ from paths_cli.wizard.plugin_classes import (
 from paths_cli.wizard.helper import EvalHelperFunc, Helper
 from paths_cli.wizard.core import interpret_req
 import paths_cli.compiling.volumes
+from paths_cli.wizard import pause
 
 
 def _binary_func_volume(wizard, context, op):
-    wizard.say("Let's make the first constituent volume:")
+    wizard.say("Let's make the first constituent volume.")
+    pause.long(wizard)
     new_context = volume_set_context(wizard, context, selected=None)
     new_context['part'] = 1
     vol1 = VOLUMES_PLUGIN(wizard, new_context)
-    wizard.say("Let's make the second constituent volume:")
+    pause.section(wizard)
+    wizard.say("Let's make the second constituent volume.")
+    pause.long(wizard)
     new_context['part'] = 2
     vol2 = VOLUMES_PLUGIN(wizard, new_context)
+    pause.section(wizard)
     wizard.say("Now we'll combine those two constituent volumes...")
     vol = op(vol1, vol2)
     return vol

--- a/paths_cli/wizard/wizard.py
+++ b/paths_cli/wizard/wizard.py
@@ -12,6 +12,8 @@ from paths_cli.wizard.joke import name_joke
 from paths_cli.wizard.helper import Helper, QuitWizard
 from paths_cli.compiling.tools import custom_eval
 
+from paths_cli.wizard import pause
+
 import shutil
 
 class Console:  # no-cov
@@ -25,6 +27,9 @@ class Console:  # no-cov
     @property
     def width(self):
         return shutil.get_terminal_size((80, 24)).columns
+
+    def draw_hline(self):
+        self.print('═' * self.width)
 
 class Wizard:
     def __init__(self, steps):
@@ -299,6 +304,7 @@ class Wizard:
             self.say("Okay, let's try that again.")
             return True
         self.register(obj, step.display_name, step.store_name)
+        pause.section(self)
         requires_another, allows_another = self._req_do_another(req)
         if requires_another:
             do_another = True


### PR DESCRIPTION
This PR will address the need for pauses in the wizard. Currently, the wizard hops from one step to the next very quickly; a brief pause (and possibly some visual cues) will improve UX by making it easier to track what is happening.

This addresses one of the targets for before v0.3 raised in #57:

* Add pauses at various points to give better UX
  * creating subvolumes
  * after naming an object

Tasks
- [x] Write basic pausing module, which can be reused (and which allows customization of delays)
- [x] Tests for pausing module
- [x] Add pause before creating subvolumes
- [x] Add pause after each object is created
- [x] Fix unit tests so that `'nopause'` pause style is used in test suite