### PR TITLE
Wizard: Fix uncaught exception if user input is empty

### DIFF
--- a/paths_cli/tests/wizard/test_wizard.py
+++ b/paths_cli/tests/wizard/test_wizard.py
@@ -81,6 +81,20 @@ class TestWizard:
         assert result == 'foo'
         assert 'You said: helpme' in console.log_text
 
+    @pytest.mark.parametrize('autohelp', [True, False])
+    def test_ask_empty(self, autohelp):
+        # if the use response in an empty string, we should repeat the
+        # question (possible giving autohelp). This fixes a regression where
+        # an empty string would cause an uncaught exception.
+        console = MockConsole(['', 'foo'])
+        self.wizard.console = console
+        result = self.wizard.ask("question",
+                                 helper=lambda x: "say_help",
+                                 autohelp=autohelp)
+        assert result == "foo"
+        if autohelp:
+            assert "say_help" in self.wizard.console.log_text
+
     def _generic_speak_test(self, func_name):
         console = MockConsole()
         self.wizard.console = console

--- a/paths_cli/wizard/wizard.py
+++ b/paths_cli/wizard/wizard.py
@@ -85,6 +85,11 @@ class Wizard:
             helper = Helper(helper)
         result = self.console.input("🧙 " + question + " ")
         self.console.print()
+        if result == "":
+            if not autohelp:
+                return
+            result = "?"  # autohelp in this case
+
         if helper and result[0] in ["?", "!"]:
             self.say(helper(result))
             return


### PR DESCRIPTION
Previously, if the user input was the empty string, the code checking for help/command (looking are `user_input[0]` would error out. This prevents that error from occurring.