### PR TITLE
pylint/flake8: `paths_cli.wizard`

### DIFF
--- a/paths_cli/tests/wizard/test_load_from_ops.py
+++ b/paths_cli/tests/wizard/test_load_from_ops.py
@@ -6,7 +6,7 @@ import openpathsampling as paths
 from paths_cli.tests.wizard.mock_wizard import mock_wizard
 
 from paths_cli.wizard.load_from_ops import (
-    named_objs_helper, _get_ops_storage, _get_ops_object, load_from_ops
+    _get_ops_storage, _get_ops_object, load_from_ops
 )
 
 # for some reason I couldn't get these to work with MagicMock
@@ -44,12 +44,6 @@ def ops_file_fixture():
     storage = FakeStorage(foo)
     return storage
 
-def test_named_objs_helper(ops_file_fixture):
-    helper_func = named_objs_helper(ops_file_fixture, 'foo')
-    result = helper_func('any')
-    assert "what I found" in result
-    assert "bar" in result
-    assert "baz" in result
 
 @pytest.mark.parametrize('with_failure', [False, True])
 def test_get_ops_storage(tmpdir, with_failure):

--- a/paths_cli/wizard/core.py
+++ b/paths_cli/wizard/core.py
@@ -1,12 +1,17 @@
-import random
-from paths_cli.wizard.tools import a_an
-
-from collections import namedtuple
-
-WIZARD_STORE_NAMES = ['engines', 'cvs', 'states', 'networks', 'schemes']
-WizardSay = namedtuple("WizardSay", ['msg', 'mode'])
-
 def interpret_req(req):
+    """Create user-facing string representation of the input requirement.
+
+    Parameters
+    ----------
+    req : Tuple[..., int, int]
+        req[1] is the minimum number of objects to create; req[2] is the
+        maximum number of objects to create
+
+    Returns
+    -------
+    str :
+        human-reading string for how many objects to create
+    """
     _, min_, max_ = req
     string = ""
     if min_ == max_:
@@ -23,7 +28,32 @@ def interpret_req(req):
     return string
 
 
+# TODO: REFACTOR: It looks like get_missing_object may be redundant with
+# other code for obtaining prerequisites for a function
 def get_missing_object(wizard, obj_dict, display_name, fallback_func):
+    """Get a prerequisite object.
+
+    The ``obj_dict`` here is typically a mapping of objects known by the
+    Wizard. If it is empty, the ``fallback_func`` is used to create a new
+    object. If it has exactly 1 entry, that is used implicitly. If it has
+    more than 1 entry, the user must select which one to use.
+
+    Parameters
+    ----------
+    wizard : :class:`.Wizard`
+        the wizard for user interaction
+    obj_dict : Dict[str, Any]
+        mapping of object name to object
+    display_name: str
+        the user-facing name of this type of object
+    fallback_func: Callable[:class:`.Wizard`] -> Any
+        method to create a new object of this type
+
+    Returns
+    -------
+    Any :
+        the prerequisite object
+    """
     if len(obj_dict) == 0:
         obj = fallback_func(wizard)
     elif len(obj_dict) == 1:
@@ -37,10 +67,22 @@ def get_missing_object(wizard, obj_dict, display_name, fallback_func):
 
 
 def get_object(func):
+    """Decorator to wrap methods for obtaining objects from user input.
+
+    This decorator implements the user interaction loop when dealing with a
+    single user input. The wrapped function is intended to create some
+    object. If the user's input cannot create a valid object, the wrapped
+    function should return None.
+
+    Parameters
+    ----------
+    func : Callable
+        object creation method to wrap; should return None on failure
+    """
+    # TODO: use functools.wraps?
     def inner(*args, **kwargs):
         obj = None
         while obj is None:
             obj = func(*args, **kwargs)
         return obj
     return inner
-

--- a/paths_cli/wizard/engines.py
+++ b/paths_cli/wizard/engines.py
@@ -1,6 +1,4 @@
-import paths_cli.wizard.openmm as openmm
 from paths_cli.wizard.plugin_classes import LoadFromOPS, WrapCategory
-from functools import partial
 
 _ENGINE_HELP = "An engine describes how you'll do the actual dynamics."
 ENGINE_PLUGIN = WrapCategory(
@@ -17,4 +15,3 @@ ENGINE_FROM_FILE = LoadFromOPS('engine')
 if __name__ == "__main__":  # no-cov
     from paths_cli.wizard.run_module import run_category
     run_category('engine')
-

--- a/paths_cli/wizard/errors.py
+++ b/paths_cli/wizard/errors.py
@@ -1,23 +1,42 @@
 class ImpossibleError(Exception):
+    """Error to throw for sections that should be unreachable code"""
     def __init__(self, msg=None):
         if msg is None:
             msg = "Something went really wrong. You should never see this."
         super().__init__(msg)
 
+
 class RestartObjectException(BaseException):
+    """Exception to indicate the restart of an object.
+
+    Raised when the user issues a command to cause an object restart.
+    """
     pass
 
+
 def not_installed(wizard, package, obj_type):
+    """Behavior when an integration is not installed.
+
+    In actual practice, this calling code should ensure this doesn't get
+    used. However, we keep it around as a defensive practice.
+
+    Parameters
+    ----------
+    package : str
+        name of the missing package
+    obj_type : str
+        name of the object category that would have been created
+    """
     retry = wizard.ask(f"Hey, it looks like you don't have {package} "
                        "installed. Do you want to try a different "
                        f"{obj_type}, or do you want to quit?",
                        options=["[R]etry", "[Q]uit"])
     if retry == 'r':
         raise RestartObjectException()
-    elif retry == 'q':
+    if retry == 'q':
+        # TODO: maybe raise QuitWizard instead?
         exit()
-    else:  # no-cov
-        raise ImpossibleError()
+    raise ImpossibleError()
 
 
 FILE_LOADING_ERROR_MSG = ("Sorry, something went wrong when loading that "

--- a/paths_cli/wizard/errors.py
+++ b/paths_cli/wizard/errors.py
@@ -36,7 +36,7 @@ def not_installed(wizard, package, obj_type):
     if retry == 'q':
         # TODO: maybe raise QuitWizard instead?
         exit()
-    raise ImpossibleError()
+    raise ImpossibleError()  # -no-cov-
 
 
 FILE_LOADING_ERROR_MSG = ("Sorry, something went wrong when loading that "

--- a/paths_cli/wizard/errors.py
+++ b/paths_cli/wizard/errors.py
@@ -30,7 +30,7 @@ def not_installed(wizard, package, obj_type):
     retry = wizard.ask(f"Hey, it looks like you don't have {package} "
                        "installed. Do you want to try a different "
                        f"{obj_type}, or do you want to quit?",
-                       options=["[R]etry", "[Q]uit"])
+                       options=["[r]etry", "[q]uit"])
     if retry == 'r':
         raise RestartObjectException()
     if retry == 'q':

--- a/paths_cli/wizard/helper.py
+++ b/paths_cli/wizard/helper.py
@@ -1,24 +1,31 @@
+import sys
 from .errors import RestartObjectException
 
 
 class QuitWizard(BaseException):
-    pass
+    """Exception raised when user expresses desire to quit the wizard"""
 
 
 # the following command functions take cmd and ctx -- future commands might
 # use the full command text or the context internally.
 
 def raise_quit(cmd, ctx):
+    """Command function to quit the wizard (with option to save).
+    """
     raise QuitWizard()
 
 
 def raise_restart(cmd, ctx):
+    """Command function to restart the current object.
+    """
     raise RestartObjectException()
 
 
 def force_exit(cmd, ctx):
+    """Command function to force immediate exit.
+    """
     print("Exiting...")
-    exit()
+    sys.exit()
 
 
 HELPER_COMMANDS = {

--- a/paths_cli/wizard/joke.py
+++ b/paths_cli/wizard/joke.py
@@ -16,9 +16,11 @@ _MISC = [
     "It would also be a good name for a death metal band.",
 ]
 
+
 def _joke1(name, obj_type):  # no-cov
     return (f"I probably would have named it something like "
             f"'{random.choice(_NAMES)}'.")
+
 
 def _joke2(name, obj_type):  # no-cov
     thing = random.choice(_THINGS)
@@ -26,20 +28,25 @@ def _joke2(name, obj_type):  # no-cov
             f"when I was young.")
     return joke
 
+
 def _joke3(name, obj_type):  # no-cov
     return (f"I wanted to name my {random.choice(_SPAWN)} '{name}', but my "
             f"wife wouldn't let me.")
+
 
 def _joke4(name, obj_type):  # no-cov
     a_an_thing = a_an(obj_type) + f" {obj_type}"
     return random.choice(_MISC).format(name=name, obj_type=obj_type,
                                        a_an_thing=a_an_thing)
 
+
 def name_joke(name, obj_type):  # no-cov
+    """Make a joke about the naming process."""
     jokes = [_joke1, _joke2, _joke3, _joke4]
     weights = [5, 5, 3, 7]
     joke = random.choices(jokes, weights=weights)[0]
     return joke(name, obj_type)
+
 
 if __name__ == "__main__":  # no-cov
     for _ in range(5):

--- a/paths_cli/wizard/load_from_ops.py
+++ b/paths_cli/wizard/load_from_ops.py
@@ -5,16 +5,6 @@ from paths_cli.wizard.errors import FILE_LOADING_ERROR_MSG
 LABEL = "Load existing from OPS file"
 
 
-def named_objs_helper(storage, store_name):
-    def list_items(user_input, context=None):
-        store = getattr(storage, store_name)
-        names = [obj for obj in store if obj.is_named]
-        outstr = "\n".join(['* ' + obj.name for obj in names])
-        return f"Here's what I found:\n\n{outstr}"
-
-    return list_items
-
-
 @get_object
 def _get_ops_storage(wizard):
     filename = wizard.ask("What file can it be found in?",
@@ -40,6 +30,24 @@ def _get_ops_object(wizard, storage, store_name, obj_name):
 
 
 def load_from_ops(wizard, store_name, obj_name):
+    """Load an object from an OPS file
+
+    Parameters
+    ----------
+    wizard : :class:`.Wizard`
+        the wizard for user interaction
+    store_name : str
+        name of the store where this object will be found
+    obj_name : str
+        name of the object to load
+
+    Returns
+    -------
+    Any :
+        the object loaded from the file
+    """
+    # TODO: this might be replaced by something in compiling to load from
+    # files
     wizard.say("Okay, we'll load it from an OPS file.")
     storage = _get_ops_storage(wizard)
     obj = _get_ops_object(wizard, storage, store_name, obj_name)

--- a/paths_cli/wizard/openmm.py
+++ b/paths_cli/wizard/openmm.py
@@ -1,21 +1,17 @@
-from paths_cli.wizard.errors import FILE_LOADING_ERROR_MSG, not_installed
-from paths_cli.wizard.core import get_object
-
-# should be able to simplify this try block when we drop OpenMM < 7.6
-from paths_cli.compat.openmm import mm, HAS_OPENMM
-
-OPENMM_SERIALIZATION_URL=(
-    "http://docs.openmm.org/latest/api-python/generated/"
-    "openmm.openmm.XmlSerializer.html"
-)
+from paths_cli.compat.openmm import HAS_OPENMM
 
 from paths_cli.wizard.parameters import ProxyParameter
 from paths_cli.wizard.plugin_classes import WizardParameterObjectPlugin
 
 from paths_cli.compiling.engines import OPENMM_PLUGIN as OPENMM_COMPILING
 
-_where_is_xml = "Where is the XML file for your OpenMM {obj_type}?"
-_xml_help = (
+OPENMM_SERIALIZATION_URL = (
+    "http://docs.openmm.org/latest/api-python/generated/"
+    "openmm.openmm.XmlSerializer.html"
+)
+
+_WHERE_IS_XML = "Where is the XML file for your OpenMM {obj_type}?"
+_XML_HELP = (
     "You can write OpenMM objects like systems and integrators to XML "
     "files using the XMLSerializer class. Learn more here:\n"
     + OPENMM_SERIALIZATION_URL
@@ -43,13 +39,13 @@ if HAS_OPENMM:
             ),
             ProxyParameter(
                 name='integrator',
-                ask=_where_is_xml.format(obj_type='integrator'),
-                helper=_xml_help,
+                ask=_WHERE_IS_XML.format(obj_type='integrator'),
+                helper=_XML_HELP,
             ),
             ProxyParameter(
                 name='system',
-                ask=_where_is_xml.format(obj_type="system"),
-                helper=_xml_help,
+                ask=_WHERE_IS_XML.format(obj_type="system"),
+                helper=_XML_HELP,
             ),
             ProxyParameter(
                 name='n_steps_per_frame',

--- a/paths_cli/wizard/parameters.py
+++ b/paths_cli/wizard/parameters.py
@@ -1,8 +1,5 @@
-from paths_cli.compiling.tools import custom_eval
-import importlib
 from collections import namedtuple
 
-from paths_cli.wizard.helper import Helper
 from paths_cli.compiling.root_compiler import _CategoryCompilerProxy
 from paths_cli.wizard.standard_categories import get_category_info
 
@@ -15,6 +12,7 @@ ProxyParameter = namedtuple(
     ['name', 'ask', 'helper', 'default', 'autohelp', 'summarize'],
     defaults=[None, NO_DEFAULT, False, None]
 )
+
 
 class WizardParameter:
     """Load a single parameter from the wizard.
@@ -47,7 +45,7 @@ class WizardParameter:
         self.default = default
         self.autohelp = autohelp
         if summarize is None:
-            summarize = lambda obj: str(obj)
+            summarize = str
         self.summarize = summarize
 
     @classmethod
@@ -66,15 +64,17 @@ class WizardParameter:
         loader = loader_dict[proxy.name]
         if isinstance(loader, _CategoryCompilerProxy):
             # TODO: can this import now be moved to top of file?
-            from paths_cli.wizard.plugin_registration import get_category_wizard
+            from paths_cli.wizard.plugin_registration import \
+                    get_category_wizard
             category = loader.category
             dct['loader'] = get_category_wizard(category)
             dct['ask'] = get_category_info(category).singular
             dct['store_name'] = get_category_info(category).storage
-            cls = _ExistingObjectParameter
+            cls_ = _ExistingObjectParameter
         else:
+            cls_ = cls
             dct['loader'] = loader
-        return cls(**dct)
+        return cls_(**dct)
 
     def __call__(self, wizard, context):
         """Load the parameter.
@@ -268,7 +268,8 @@ class FromWizardPrerequisite:
         if n_existing == self.n_required:
             # early return in this case (return silently)
             return {self.name: self._get_existing(wizard)}
-        elif n_existing > self.n_required:
+
+        if n_existing > self.n_required:
             sel = [self._select_single_existing(wizard)
                    for _ in range(self.n_required)]
             dct = {self.name: sel}

--- a/paths_cli/wizard/plugin_classes.py
+++ b/paths_cli/wizard/plugin_classes.py
@@ -7,7 +7,8 @@ from paths_cli.wizard.helper import Helper
 
 
 class WizardObjectPluginRegistrationError(Exception):
-    pass
+    """Error during wizard object plugin registration.
+    """
 
 
 _PLUGIN_DOCSTRING = """
@@ -29,6 +30,7 @@ _WIZARD_KWONLY = """
         method to create the summary string describing the object that is
         created
 """ + _PLUGIN_DOCSTRING
+
 
 class LoadFromOPS(OPSPlugin):
     """Wizard plugin type to load from an existing OPS file.
@@ -61,6 +63,7 @@ class LoadFromOPS(OPSPlugin):
 
     def __call__(self, wizard, context=None):
         return load_from_ops(wizard, self.store_name, self.obj_name)
+
 
 def get_text_from_context(name, instance, default, wizard, context, *args,
                           **kwargs):
@@ -130,6 +133,7 @@ class WizardObjectPlugin(OPSPlugin):
         self._summary = summary  # func to summarize
 
     def default_summarize(self, wizard, context, result):
+        """Default summary function"""
         return [f"Here's what we'll make:\n  {str(result)}"]
 
     def get_summary(self, wizard, context, result):
@@ -354,8 +358,7 @@ class WrapCategory(OPSPlugin):
         """If user has provided a funtion to create context, use it."""
         if self._user_set_context:
             return self._user_set_context(wizard, context, selected)
-        else:
-            return context
+        return context
 
     def register_plugin(self, plugin):
         """Register a :class:`.WizardObjectPlugin` with this category.

--- a/paths_cli/wizard/plugin_registration.py
+++ b/paths_cli/wizard/plugin_registration.py
@@ -1,15 +1,15 @@
+import logging
 from paths_cli.wizard.plugin_classes import (
     LoadFromOPS, WizardObjectPlugin, WrapCategory
 )
 from paths_cli.utils import get_installed_plugins
 from paths_cli.plugin_management import NamespacePluginLoader
 
-import logging
 logger = logging.getLogger(__name__)
 
 
 class CategoryWizardPluginRegistrationError(Exception):
-    pass
+    """Error with wizard category plugin registration fails"""
 
 
 _CATEGORY_PLUGINS = {}
@@ -70,14 +70,15 @@ def register_plugins(plugins):
             object_plugins.append(plugin)
 
     for plugin in categories:
-        logger.debug("Registering " + str(plugin))
+        logger.debug("Registering %s", str(plugin))
         _register_category_plugin(plugin)
 
     for plugin in object_plugins:
         category = _CATEGORY_PLUGINS[plugin.category]
-        logger.debug("Registering " + str(plugin))
-        logger.debug("Category: " + str(category))
+        logger.debug("Registering %s", str(plugin))
+        logger.debug("Category: %s", str(category))
         category.register_plugin(plugin)
+
 
 def register_installed_plugins():
     """Register all Wizard plugins found in standard locations.

--- a/paths_cli/wizard/run_module.py
+++ b/paths_cli/wizard/run_module.py
@@ -2,6 +2,7 @@ from paths_cli.wizard.plugin_registration import register_installed_plugins
 from paths_cli.wizard.wizard import Wizard
 from paths_cli.wizard.plugin_registration import get_category_wizard
 
+
 # TODO: for now we ignore this for coverage -- it's mainly used for UX
 # testing by allowing each module to be run with, e.g.:
 #    python -m paths_cli.wizard.engines

--- a/paths_cli/wizard/shooting.py
+++ b/paths_cli/wizard/shooting.py
@@ -2,18 +2,19 @@ from functools import partial
 
 from paths_cli.wizard.core import get_missing_object
 from paths_cli.wizard.plugin_registration import get_category_wizard
-from paths_cli.compiling.tools import custom_eval
+
 
 engines = get_category_wizard('engine')
 
-import numpy as np
-
 
 def uniform_selector(wizard):
+    """Create a uniform selector (using the wizard)"""
     import openpathsampling as paths
     return paths.UniformSelector()
 
+
 def gaussian_selector(wizard):
+    """Create a Gaussian biased selector (using the wizard)"""
     import openpathsampling as paths
     cv_name = wizard.ask_enumerate("Which CV do you want the Gaussian to "
                                    "be based on?",
@@ -44,6 +45,7 @@ def gaussian_selector(wizard):
 
     # return allowed
 
+
 SHOOTING_SELECTORS = {
     'Uniform random': uniform_selector,
     'Gaussian bias': gaussian_selector,
@@ -59,6 +61,7 @@ def _get_selector(wizard, selectors=None):
     selector = selectors[sel](wizard)
     return selector
 
+
 def one_way_shooting(wizard, selectors=None, engine=None):
     from openpathsampling import strategies
     if engine is None:
@@ -72,6 +75,7 @@ def one_way_shooting(wizard, selectors=None, engine=None):
 
 # def two_way_shooting(wizard, selectors=None, modifiers=None):
     # pass
+
 
 def spring_shooting(wizard, engine=None):
     import openpathsampling as paths
@@ -109,10 +113,10 @@ def shooting(wizard, shooting_types=None, engine=None):
     # allowed_modifiers = get_allowed_modifiers(engine)
     # TWO_WAY = 'Two-way shooting'
     # if len(allowed_modifiers) == 0 and TWO_WAY in shooting_types:
-        # del shooting_types[TWO_WAY]
+    #     del shooting_types[TWO_WAY]
     # else:
-        # shooting_types[TWO_WAY] = partial(two_way_shooting,
-                                          # allowed_modifiers=allowed_modifiers)
+    #     shooting_types[TWO_WAY] = partial(two_way_shooting,
+    #                                       allowed_modifiers=allowed_modifiers)
 
     shooting_type = None
     if len(shooting_types) == 1:
@@ -126,4 +130,3 @@ def shooting(wizard, shooting_types=None, engine=None):
 
     shooting_strategy = shooting_type(wizard)
     return shooting_strategy
-

--- a/paths_cli/wizard/standard_categories.py
+++ b/paths_cli/wizard/standard_categories.py
@@ -23,6 +23,7 @@ _CATEGORY_LIST = [
 
 CATEGORIES = {cat.name: cat for cat in _CATEGORY_LIST}
 
+
 def get_category_info(category):
     """Obtain info for a stanard (or registered) category.
 

--- a/paths_cli/wizard/steps.py
+++ b/paths_cli/wizard/steps.py
@@ -1,8 +1,5 @@
 from collections import namedtuple
-from functools import partial
-
 from paths_cli.wizard.plugin_registration import get_category_wizard
-from paths_cli.wizard.tps import tps_scheme
 
 volumes = get_category_wizard('volume')
 
@@ -26,5 +23,3 @@ MULTIPLE_STATES_STEP = WizardStep(func=get_category_wizard('volume'),
                                   store_name="states",
                                   minimum=2,
                                   maximum=float('inf'))
-
-

--- a/paths_cli/wizard/tools.py
+++ b/paths_cli/wizard/tools.py
@@ -1,5 +1,6 @@
 def a_an(obj):
     return "an" if obj[0].lower() in "aeiou" else "a"
 
+
 def yes_no(char):
     return {'yes': True, 'no': False, 'y': True, 'n': False}[char.lower()]

--- a/paths_cli/wizard/tps.py
+++ b/paths_cli/wizard/tps.py
@@ -1,10 +1,9 @@
-from paths_cli.wizard.tools import a_an
 from paths_cli.wizard.core import get_missing_object
 from paths_cli.wizard.shooting import shooting
 from paths_cli.wizard.plugin_registration import get_category_wizard
 
-from functools import partial
 volumes = get_category_wizard('volume')
+
 
 def tps_network(wizard):
     raise NotImplementedError("Still need to add other network choices")

--- a/paths_cli/wizard/two_state_tps.py
+++ b/paths_cli/wizard/two_state_tps.py
@@ -5,9 +5,10 @@ from paths_cli.wizard.steps import (
 )
 from paths_cli.wizard.wizard import Wizard
 from paths_cli.wizard import pause
+from paths_cli.wizard.volumes import _FIRST_STATE, _VOL_DESC
 
 volumes = get_category_wizard('volume')
-from paths_cli.wizard.volumes import _FIRST_STATE, _VOL_DESC
+
 
 def two_state_tps(wizard, fixed_length=False):
     import openpathsampling as paths

--- a/paths_cli/wizard/wizard.py
+++ b/paths_cli/wizard/wizard.py
@@ -1,6 +1,5 @@
-import random
+import shutil
 import os
-from functools import partial
 import textwrap
 
 from paths_cli.wizard.tools import yes_no, a_an
@@ -14,24 +13,62 @@ from paths_cli.compiling.tools import custom_eval
 
 from paths_cli.wizard import pause
 
-import shutil
 
 class Console:  # no-cov
+    """Manage actual I/O for the Wizard.
+
+    All direct interaction with the user is performed in this class.
+    """
     # TODO: add logging so we can output the session
     def print(self, *content):
+        """Write content to screen"""
         print(*content)
 
     def input(self, content):
+        """Read user input.
+
+        Parameters
+        ----------
+        content : str
+            input prompt
+        """
         return input(content)
 
     @property
     def width(self):
+        """Terminal width in columns"""
         return shutil.get_terminal_size((80, 24)).columns
 
-    def draw_hline(self):
-        self.print('═' * self.width)
+    def draw_hline(self, char='═'):
+        """Draw a separator line.
+
+        Parameters
+        ----------
+        char : str
+            string to use for line separator
+        """
+        n_chars = self.width // len(char)
+        self.print(char * n_chars)
+
 
 class Wizard:
+    """Friendly interactive Wizard
+
+    This class handles most of the user-facing interaction with the wizard,
+    including various conveniences for asking for certain user selections
+    (such as selecting between a number of possible choices.)
+
+    An instance of this class includes information about how the Wizard will
+    guide the user through various stages of simulation set-up.
+
+    The main method, ``Wizard.run_wizard()``, performs an entire simulation
+    set-up for that instance.
+
+    Parameters
+    ----------
+    steps : List[:class:`.WizardStep`]
+        ordered list of steps in this particular simulation set-up process
+    """
     def __init__(self, steps):
         self.steps = steps
         self.requirements = {
@@ -60,7 +97,8 @@ class Wizard:
             self._patched = True
             StorageLoader.has_simstore_patch = True
 
-    def debug(content):  # no-cov
+    def debug(self, content):  # no-cov
+        """Print to console without pretty-printing"""
         # debug does no pretty-printing
         self.console.print(content)
 
@@ -84,6 +122,7 @@ class Wizard:
     @get_object
     def ask(self, question, options=None, default=None, helper=None,
             autohelp=False):
+        """Ask the user a question."""
         if helper is None:
             helper = Helper(None)
         if isinstance(helper, str):
@@ -92,30 +131,60 @@ class Wizard:
         self.console.print()
         if result == "":
             if not autohelp:
-                return
+                return None
             result = "?"  # autohelp in this case
 
         if helper and result[0] in ["?", "!"]:
             self.say(helper(result))
-            return
+            return None
         return result
 
     def say(self, content, preface="🧙 "):
+        """Let the wizard make a statement.
+
+        Parameters
+        ----------
+        content : str or List[str]
+            Content to be presented to user. Input will be wrapped to fit
+            the user's terminal. If a list of strings, each element is
+            printed with a blank line separating them.
+        preface : str
+            preface, used only on the first line of the first element of the
+            ``content``.
+        """
         self._speak(content, preface)
         self.console.print()  # adds a blank line
 
     def start(self, content):
+        """Specialized version of :method:`.say` for starting an object"""
         # eventually, this will tweak so that we preface with a line and use
-        # green text here
+        # green text here  TODO: possibly remove?
         self.say(content)
 
     def bad_input(self, content, preface="👺 "):
+        """Specialized version of :method:`.say` for printing errors"""
         # just changes the default preface; maybe print 1st line red?
         self.say(content, preface)
 
     @get_object
     def ask_enumerate_dict(self, question, options, helper=None,
                            autohelp=False):
+        """Ask the user to select from a set of options.
+
+        Parameters
+        ----------
+        question : str
+            the question to ask the user (asked before the options are
+            listed)
+        options: Dict[str, Any]
+            mapping of the string name (shown to the user in the list of
+            options) to the object to return
+
+        Returns
+        -------
+        Any :
+            the object the user selected by either name or number
+        """
         self.say(question)
         opt_string = "\n".join([f" {(i+1):>3}. {opt}"
                                 for i, opt in enumerate(options)])
@@ -138,6 +207,8 @@ class Wizard:
 
     def ask_enumerate(self, question, options):
         """Ask the user to select from a list of options"""
+        # NOTE: new code should use ask_enumerate_dict. If we were past the
+        # beta stage, this would probably issue a PendingDeprecationWarning
         self.say(question)
         opt_string = "\n".join([f" {(i+1):>3}. {opt}"
                                 for i, opt in enumerate(options)])
@@ -161,19 +232,36 @@ class Wizard:
 
     @get_object
     def ask_load(self, question, loader, helper=None, autohelp=False):
+        """Load from user input according to ``loader`` method
+
+        Parameters
+        ----------
+        question : str
+            string to ask the user
+        loader : Callable[str] -> Any
+            method that converts user input into the desired format for the
+            object
+        helper : :class:`.Helper`
+            object to handle user requests for help
+        """
         as_str = self.ask(question, helper=helper)
         try:
             result = loader(as_str)
         except Exception as e:
             self.exception(f"Sorry, I couldn't understand the input "
                            f"'{as_str}'.", e)
-            return
+            return None
         return result
 
-    # this should match the args for wizard.ask
     @get_object
     def ask_custom_eval(self, question, options=None, default=None,
                         helper=None, type_=float):
+        """Get user input and convert using custom_eval.
+
+        .. note::
+            New code should use ask_load. If we were past beta, this would
+            have a PendingDeprecationWarning.
+        """
         as_str = self.ask(question, options=options, default=default,
                           helper=helper)
         try:
@@ -181,11 +269,14 @@ class Wizard:
         except Exception as e:
             self.exception(f"Sorry, I couldn't understand the input "
                            f"'{as_str}'", e)
-            return
+            return None
         return result
 
-
     def obj_selector(self, store_name, text_name, create_func):
+        """Select an object from the wizard's pseudo-storage
+        """
+        # TODO: this seems like something that might be possible to refactor
+        # out
         opts = {name: lambda wiz, o=obj: o
                 for name, obj in getattr(self, store_name).items()}
         create_new = f"Create a new {text_name}"
@@ -198,10 +289,27 @@ class Wizard:
         return obj
 
     def exception(self, msg, exception):
+        """Specialized version of :method:`.bad_input` for exceptions"""
         self.bad_input(f"{msg}\nHere's the error I got:\n"
                        f"{exception.__class__.__name__}: {exception}")
 
-    def name(self, obj, obj_type, store_name, default=None):
+    def name(self, obj, obj_type, store_name):
+        """Name a newly created object.
+
+        Parameters
+        ----------
+        obj : Any
+            the new object
+        obj_type : str
+            user-facing name of the object type
+        store_name : str
+            name of the OPS store in which to save this object type
+
+        Returns
+        -------
+        Any :
+            named object
+        """
         self.say(f"Now let's name your {obj_type}.")
         name = None
         while name is None:
@@ -220,8 +328,23 @@ class Wizard:
                  + name_joke(name, obj_type))
         return obj
 
-
     def register(self, obj, obj_type, store_name):
+        """Register a newly-created object in the storage
+
+        Parameters
+        ----------
+        obj : Any
+            the new object
+        obj_type : str
+            user-facing name of the object type
+        store_name : str
+            name of the OPS store in which to save this object type
+
+        Returns
+        -------
+        Any :
+            input object, possibly after being named
+        """
         if not obj.is_named:
             obj = self.name(obj, obj_type, store_name)
         store_dict = getattr(self, store_name)
@@ -230,31 +353,38 @@ class Wizard:
 
     @get_object
     def get_storage(self):
+        """Create a file to store the object database to.
+
+        Returns
+        -------
+        :class:`openpathsampling.experimental.storage.Storage` :
+            the storage file object
+        """
         from openpathsampling.experimental.storage import Storage
         filename = self.ask("Where would you like to save your setup "
                             "database?")
         if not filename.endswith(".db"):
             self.bad_input("Files produced by this wizard must end in "
                            "'.db'.")
-            return
+            return None
 
         if os.path.exists(filename):
             overwrite = self.ask(f"{filename} exists. Overwrite it?",
                                  options=["[Y]es", "[N]o"])
             overwrite = yes_no(overwrite)
             if not overwrite:
-                return
+                return None
 
         try:
             storage = Storage(filename, mode='w')
         except Exception as e:
             self.exception(FILE_LOADING_ERROR_MSG, e)
-            return
+            return None
 
         return storage
 
-
     def _storage_description_line(self, store_name):
+        """List number of each type of object to be stored"""
         store = getattr(self, store_name)
         if len(store) == 0:
             return ""
@@ -266,6 +396,13 @@ class Wizard:
         return line
 
     def save_to_file(self, storage):
+        """Save Wizard's pseudostorage to a real file.
+
+        Parameters
+        ----------
+        storage : :class:`openpathsampling.experimental.storage.Storage`
+            storage file to save to
+        """
         store_names = ['engines', 'cvs', 'states', 'networks', 'schemes']
         lines = [self._storage_description_line(store_name)
                  for store_name in store_names]
@@ -280,6 +417,7 @@ class Wizard:
         self.say("Success! Everything has been stored in your file.")
 
     def _req_do_another(self, req):
+        """Check whether requirement requires us to do another"""
         store, min_, max_ = req
         if store is None:
             return (True, False)
@@ -290,6 +428,7 @@ class Wizard:
         return requires, allows
 
     def _ask_do_another(self, obj_type):
+        """Ask the user whether to do another"""
         do_another = None
         while do_another is None:
             do_another_char = self.ask(
@@ -303,6 +442,7 @@ class Wizard:
         return do_another
 
     def _do_one(self, step, req):
+        """Create a single object of the sort generated by ``step``"""
         try:
             obj = step.func(self)
         except RestartObjectException:
@@ -320,6 +460,7 @@ class Wizard:
         return do_another
 
     def run_wizard(self):
+        """Run this Wizard."""
         self.start("Hi! I'm the OpenPathSampling Wizard.")
         # TODO: next line is only temporary
         self.say("Today I'll help you set up a 2-state TPS simulation.")
@@ -343,6 +484,7 @@ class Wizard:
 
     @get_object
     def _ask_save(self):
+        """Ask user whether to save before quitting"""
         do_save_char = self.ask("Before quitting, would you like to save "
                                 "the objects you've created so far?")
         try:


### PR DESCRIPTION
This performs the pylint/flake8 cleanup for the `wizard` subpackage requested in #57. Mainly this involved removing some unused imports and unused code and adding a lot of docstrings.

The Wizard API is still expected to be in a state of rapid flux (even after the v0.3 release) so some parameters that are likely to be removed are not always documented, and some methods that are likely to be removed are only partly documented. I also marked a few things as likely to change in the near future.

Code style exceptions to pylint/flake8 rules here: https://gist.github.com/dwhswenson/1361b849866af98e7f8e6599810670b2