### PR TITLE
Fill in information for `compile` docs

### DIFF
--- a/paths_cli/compiling/_gendocs/docs_generator.py
+++ b/paths_cli/compiling/_gendocs/docs_generator.py
@@ -104,7 +104,7 @@ class DocsGenerator:
             default="",
             description="name this object in order to reuse it",
         )
-        rst += self.format_parameter(name_param, type_str=" (*string*)")
+        rst += self.format_parameter(name_param, type_str=" (string)")
         for param in plugin.parameters:
             type_str = f" ({json_type_to_string(param.json_type)})"
             rst += self.format_parameter(param, type_str)

--- a/paths_cli/compiling/_gendocs/json_type_handlers.py
+++ b/paths_cli/compiling/_gendocs/json_type_handlers.py
@@ -146,6 +146,8 @@ JSON_TYPE_HANDLERS = [
     CategoryHandler("network"),
     CategoryHandler("strategy"),
     CategoryHandler("scheme"),
+    CategoryHandler("shooting-point-selector"),
+    CategoryHandler("interface-set"),
     EvalHandler("EvalInt"),
     EvalHandler("EvalIntStrictPos"),
     EvalHandler("EvalFloat"),

--- a/paths_cli/compiling/_gendocs/json_type_handlers.py
+++ b/paths_cli/compiling/_gendocs/json_type_handlers.py
@@ -53,6 +53,12 @@ handle_listof = JsonTypeHandler(
 )
 
 
+handle_none = JsonTypeHandler(
+    is_my_type=lambda obj: obj is None,
+    handler=lambda json_type: "type information missing",
+)
+
+
 class RefTypeHandler(JsonTypeHandler):
     """Handle JSON types of the form {"$ref": "#/definitions/..."}
 
@@ -122,6 +128,9 @@ class EvalHandler(RefTypeHandler):
         to the anchor given by ``link_to``
     """
     def __init__(self, type_name, link_to=None):
+        if link_to is None:
+            link_to = type_name
+
         super().__init__(
             type_name=type_name, def_string=type_name, link_to=link_to
         )
@@ -129,6 +138,7 @@ class EvalHandler(RefTypeHandler):
 
 JSON_TYPE_HANDLERS = [
     handle_object,
+    handle_none,
     handle_listof,
     CategoryHandler("engine"),
     CategoryHandler("cv"),

--- a/paths_cli/compiling/_gendocs/json_type_handlers.py
+++ b/paths_cli/compiling/_gendocs/json_type_handlers.py
@@ -133,7 +133,11 @@ JSON_TYPE_HANDLERS = [
     CategoryHandler("engine"),
     CategoryHandler("cv"),
     CategoryHandler("volume"),
+    CategoryHandler("network"),
+    CategoryHandler("strategy"),
+    CategoryHandler("scheme"),
     EvalHandler("EvalInt"),
+    EvalHandler("EvalIntStrictPos"),
     EvalHandler("EvalFloat"),
 ]
 

--- a/paths_cli/compiling/cvs.py
+++ b/paths_cli/compiling/cvs.py
@@ -4,6 +4,7 @@ from paths_cli.compiling.topology import build_topology
 from paths_cli.compiling.errors import InputError
 from paths_cli.utils import import_thing
 from paths_cli.compiling.plugins import CVCompilerPlugin, CategoryPlugin
+from paths_cli.compiling.json_type import json_type_eval
 
 
 class AllowedPackageHandler:
@@ -40,13 +41,16 @@ MDTRAJ_CV_PLUGIN = CVCompilerPlugin(
                   json_type='object', default=None,
                   description="keyword arguments for ``func``"),
         Parameter('period_min', custom_eval, default=None,
+                  json_type=json_type_eval('Float'),
                   description=("minimum value for a periodic function, "
                                "None if not periodic")),
         Parameter('period_max', custom_eval, default=None,
+                  json_type=json_type_eval('Float'),
                   description=("maximum value for a periodic function, "
                                "None if not periodic")),
 
     ],
+    description="Use an MDTraj analysis function to calculate a CV.",
     name="mdtraj"
 )
 

--- a/paths_cli/compiling/cvs.py
+++ b/paths_cli/compiling/cvs.py
@@ -1,5 +1,5 @@
 from paths_cli.compiling.core import Parameter, Builder
-from paths_cli.compiling.tools import custom_eval
+from paths_cli.compiling.tools import custom_eval, custom_eval_float
 from paths_cli.compiling.topology import build_topology
 from paths_cli.compiling.errors import InputError
 from paths_cli.utils import import_thing
@@ -40,11 +40,11 @@ MDTRAJ_CV_PLUGIN = CVCompilerPlugin(
                                             for key, arg in kwargs.items()},
                   json_type='object', default=None,
                   description="keyword arguments for ``func``"),
-        Parameter('period_min', custom_eval, default=None,
+        Parameter('period_min', custom_eval_float, default=None,
                   json_type=json_type_eval('Float'),
                   description=("minimum value for a periodic function, "
                                "None if not periodic")),
-        Parameter('period_max', custom_eval, default=None,
+        Parameter('period_max', custom_eval_float, default=None,
                   json_type=json_type_eval('Float'),
                   description=("maximum value for a periodic function, "
                                "None if not periodic")),

--- a/paths_cli/compiling/engines.py
+++ b/paths_cli/compiling/engines.py
@@ -3,6 +3,7 @@ from paths_cli.compiling.core import Builder
 from paths_cli.compiling.core import Parameter
 from paths_cli.compiling.tools import custom_eval_int_strict_pos
 from paths_cli.compiling.plugins import EngineCompilerPlugin, CategoryPlugin
+from paths_cli.compiling.json_type import json_type_eval
 
 
 def load_openmm_xml(filename):
@@ -34,8 +35,10 @@ OPENMM_PARAMETERS = [
     Parameter('integrator', load_openmm_xml, json_type='string',
               description="XML file with the OpenMM integrator"),
     Parameter('n_steps_per_frame', custom_eval_int_strict_pos,
+              json_type=json_type_eval('IntStrictPos'),
               description="number of MD steps per saved frame"),
     Parameter("n_frames_max", custom_eval_int_strict_pos,
+              json_type=json_type_eval('IntStrictPos'),
               description=("maximum number of frames before aborting "
                            "trajectory")),
 ]

--- a/paths_cli/compiling/gendocs.py
+++ b/paths_cli/compiling/gendocs.py
@@ -9,6 +9,11 @@ from paths_cli.commands.compile import register_installed_plugins
 @click.option("--stdout", type=bool, is_flag=True, default=False)
 def main(config_file, stdout):
     """Generate documentation for installed compiling plugins."""
+    do_main(config_file, stdout)
+
+
+def do_main(config_file, stdout=False):
+    """Separate method so this can be imported and run"""
     register_installed_plugins()
     config = load_config(config_file)
     generator = DocsGenerator(config)

--- a/paths_cli/compiling/json_type.py
+++ b/paths_cli/compiling/json_type.py
@@ -1,3 +1,10 @@
 
 def json_type_ref(category):
     return {"$ref": f"#/definitions/{category}_type"}
+
+def json_type_eval(check_type):
+    return {"$ref": f"#/definitions/Eval{check_type}"}
+
+def json_type_list(item_type):
+    return {'type': 'array',
+            'items': item_type}

--- a/paths_cli/compiling/networks.py
+++ b/paths_cli/compiling/networks.py
@@ -2,13 +2,44 @@ from paths_cli.compiling.core import (
     InstanceCompilerPlugin, Builder, Parameter
 )
 from paths_cli.compiling.tools import custom_eval
-from paths_cli.compiling.plugins import NetworkCompilerPlugin, CategoryPlugin
+from paths_cli.compiling.plugins import (
+    NetworkCompilerPlugin, CategoryPlugin, InterfaceSetPlugin
+)
 from paths_cli.compiling.root_compiler import compiler_for
 from paths_cli.compiling.json_type import (
     json_type_ref, json_type_list, json_type_eval
 )
 
-build_interface_set = InstanceCompilerPlugin(
+
+INITIAL_STATES_PARAM = Parameter(
+    'initial_states', compiler_for('volume'),
+    json_type=json_type_list(json_type_ref('volume')),
+    description="initial states for this transition",
+)
+
+
+INITIAL_STATE_PARAM = Parameter(
+    'initial_state', compiler_for('volume'),
+    json_type=json_type_list(json_type_ref('volume')),
+    description="initial state for this transition",
+)
+
+
+FINAL_STATES_PARAM = Parameter(
+    'final_states', compiler_for('volume'),
+    json_type=json_type_list(json_type_ref('volume')),
+    description="final states for this transition",
+)
+
+
+FINAL_STATE_PARAM = Parameter(
+    'final_state', compiler_for('volume'),
+    json_type=json_type_list(json_type_ref('volume')),
+    description="final state for this transition",
+)
+
+
+build_interface_set = InterfaceSetPlugin(
     builder=Builder('openpathsampling.VolumeInterfaceSet'),
     parameters=[
         Parameter('cv', compiler_for('cv'), json_type=json_type_ref('cv'),
@@ -23,7 +54,8 @@ build_interface_set = InstanceCompilerPlugin(
                   description=("maximum value(s) for interfaces in this"
                                "interface set")),
     ],
-    name='interface-set'
+    name='interface-set',
+    description="Interface set used in transition interface sampling.",
 )
 
 
@@ -57,15 +89,10 @@ def tis_trans_info(dct):
 
 TPS_NETWORK_PLUGIN = NetworkCompilerPlugin(
     builder=Builder('openpathsampling.TPSNetwork'),
-    parameters=[
-        Parameter('initial_states', compiler_for('volume'),
-                  json_type=json_type_list(json_type_ref('volume')),
-                  description="initial states for this transition"),
-        Parameter('final_states', compiler_for('volume'),
-                  json_type=json_type_list(json_type_ref('volume')),
-                  description="final states for this transition")
-    ],
-    name='tps'
+    parameters=[INITIAL_STATES_PARAM, FINAL_STATES_PARAM],
+    name='tps',
+    description=("Network for transition path sampling (two state TPS or "
+                 "multiple state TPS)."),
 )
 
 

--- a/paths_cli/compiling/networks.py
+++ b/paths_cli/compiling/networks.py
@@ -69,24 +69,22 @@ TPS_NETWORK_PLUGIN = NetworkCompilerPlugin(
 )
 
 
-MISTIS_NETWORK_PLUGIN = NetworkCompilerPlugin(
-    parameters=[Parameter('trans_info', mistis_trans_info)],
-    builder=Builder('openpathsampling.MISTISNetwork'),
-    name='mistis'
-)
+# MISTIS_NETWORK_PLUGIN = NetworkCompilerPlugin(
+#     parameters=[Parameter('trans_info', mistis_trans_info)],
+#     builder=Builder('openpathsampling.MISTISNetwork'),
+#     name='mistis'
+# )
 
 
-TIS_NETWORK_PLUGIN = NetworkCompilerPlugin(
-    builder=Builder('openpathsampling.MISTISNetwork'),
-    parameters=[Parameter('trans_info', tis_trans_info)],
-    name='tis'
-)
+# TIS_NETWORK_PLUGIN = NetworkCompilerPlugin(
+#     builder=Builder('openpathsampling.MISTISNetwork'),
+#     parameters=[Parameter('trans_info', tis_trans_info)],
+#     name='tis'
+# )
 
 # old names not yet replaced in testing  THESE ARE WHY WE'RE DOUBLING! GET
 # RID OF THEM! (also, use an is-check)
 build_tps_network = TPS_NETWORK_PLUGIN
-build_mistis_network = MISTIS_NETWORK_PLUGIN
-build_tis_network = TIS_NETWORK_PLUGIN
 
 
 NETWORK_COMPILER = CategoryPlugin(NetworkCompilerPlugin, aliases=['networks'])

--- a/paths_cli/compiling/networks.py
+++ b/paths_cli/compiling/networks.py
@@ -4,14 +4,24 @@ from paths_cli.compiling.core import (
 from paths_cli.compiling.tools import custom_eval
 from paths_cli.compiling.plugins import NetworkCompilerPlugin, CategoryPlugin
 from paths_cli.compiling.root_compiler import compiler_for
+from paths_cli.compiling.json_type import (
+    json_type_ref, json_type_list, json_type_eval
+)
 
 build_interface_set = InstanceCompilerPlugin(
     builder=Builder('openpathsampling.VolumeInterfaceSet'),
     parameters=[
-        Parameter('cv', compiler_for('cv'), description="the collective "
-                  "variable for this interface set"),
-        Parameter('minvals', custom_eval),  # TODO fill in JSON types
-        Parameter('maxvals', custom_eval),  # TODO fill in JSON types
+        Parameter('cv', compiler_for('cv'), json_type=json_type_ref('cv'),
+                  description=("the collective variable for this interface "
+                               "set")),
+        Parameter('minvals', custom_eval,
+                  json_type=json_type_list(json_type_eval("Float")),
+                  description=("minimum value(s) for interfaces in this"
+                               "interface set")),
+        Parameter('maxvals', custom_eval,
+                  json_type=json_type_list(json_type_eval("Float")),
+                  description=("maximum value(s) for interfaces in this"
+                               "interface set")),
     ],
     name='interface-set'
 )
@@ -49,8 +59,10 @@ TPS_NETWORK_PLUGIN = NetworkCompilerPlugin(
     builder=Builder('openpathsampling.TPSNetwork'),
     parameters=[
         Parameter('initial_states', compiler_for('volume'),
+                  json_type=json_type_list(json_type_ref('volume')),
                   description="initial states for this transition"),
         Parameter('final_states', compiler_for('volume'),
+                  json_type=json_type_list(json_type_ref('volume')),
                   description="final states for this transition")
     ],
     name='tps'

--- a/paths_cli/compiling/plugins.py
+++ b/paths_cli/compiling/plugins.py
@@ -45,3 +45,11 @@ class SchemeCompilerPlugin(InstanceCompilerPlugin):
 
 class StrategyCompilerPlugin(InstanceCompilerPlugin):
     category = 'strategy'
+
+
+class ShootingPointSelectorPlugin(InstanceCompilerPlugin):
+    category = 'shooting-point-selector'
+
+
+class InterfaceSetPlugin(InstanceCompilerPlugin):
+    category = 'interface-set'

--- a/paths_cli/compiling/root_compiler.py
+++ b/paths_cli/compiling/root_compiler.py
@@ -18,7 +18,7 @@ _DEFAULT_COMPILE_ORDER = [
     'volume',
     'state',
     'network',
-    'movescheme',
+    'scheme',
 ]
 
 COMPILE_ORDER = _DEFAULT_COMPILE_ORDER.copy()

--- a/paths_cli/compiling/root_compiler.py
+++ b/paths_cli/compiling/root_compiler.py
@@ -70,8 +70,8 @@ def _get_compiler(category):
     canonical_name = _canonical_name(category)
     # create a new compiler if none exists
     if canonical_name is None:
-        canonical_name = category
-        _COMPILERS[category] = CategoryCompiler(None, category)
+        canonical_name = clean_input_key(category)
+        _COMPILERS[canonical_name] = CategoryCompiler(None, category)
     return _COMPILERS[canonical_name]
 
 

--- a/paths_cli/compiling/schemes.py
+++ b/paths_cli/compiling/schemes.py
@@ -45,6 +45,9 @@ SPRING_SHOOTING_PLUGIN = SchemeCompilerPlugin(
         ENGINE_PARAMETER
     ],
     name='spring-shooting',
+    description=("Move scheme for TPS with the spring-shooting algorithm. "
+                 "Under most circumstances, the network provided here "
+                 "should be a 2-state TPS network."),
 )
 
 
@@ -78,6 +81,8 @@ ONE_WAY_SHOOTING_SCHEME_PLUGIN = SchemeCompilerPlugin(
         STRATEGIES_PARAMETER,
     ],
     name='one-way-shooting',
+    description=("One-way-shooting move scheme. This can be extended with "
+                 "additional user-defined move strategies."),
 )
 
 MOVESCHEME_PLUGIN = SchemeCompilerPlugin(
@@ -87,7 +92,11 @@ MOVESCHEME_PLUGIN = SchemeCompilerPlugin(
         NETWORK_PARAMETER,
         STRATEGIES_PARAMETER,
     ],
-    name='scheme'
+    name='scheme',
+    description=("Generic move scheme. Add strategies to this to make it "
+                 "useful. This defaults to a scheme that first chooses a "
+                 "move type, and then chooses the specific move within "
+                 "that type (i.e., ``OrganizeByMoveGroupStrategy``)"),
 )
 
 SCHEME_COMPILER = CategoryPlugin(SchemeCompilerPlugin, aliases=['schemes'])

--- a/paths_cli/compiling/schemes.py
+++ b/paths_cli/compiling/schemes.py
@@ -1,17 +1,32 @@
 from paths_cli.compiling.core import (
     Builder, Parameter
 )
-from paths_cli.compiling.tools import custom_eval
+from paths_cli.compiling.tools import (
+    custom_eval, custom_eval_int_strict_pos
+)
 from paths_cli.compiling.strategies import SP_SELECTOR_PARAMETER
 from paths_cli.compiling.plugins import SchemeCompilerPlugin, CategoryPlugin
 from paths_cli.compiling.root_compiler import compiler_for
+from paths_cli.compiling.json_type import (
+    json_type_ref, json_type_list, json_type_eval
+)
 
 
-NETWORK_PARAMETER = Parameter('network', compiler_for('network'))
+NETWORK_PARAMETER = Parameter(
+    'network',
+    compiler_for('network'),
+    json_type=json_type_ref('network'),
+    description="network to use with this scheme"
+)
 
-ENGINE_PARAMETER = Parameter('engine', compiler_for('engine'))  # reuse?
+ENGINE_PARAMETER = Parameter(
+    'engine', compiler_for('engine'),
+    json_type=json_type_ref('engine'),
+    description="engine to use with this scheme",
+)  # reuse?
 
 STRATEGIES_PARAMETER = Parameter('strategies', compiler_for('strategy'),
+                                 json_type=json_type_ref('strategy'),
                                  default=None)
 
 
@@ -19,8 +34,14 @@ SPRING_SHOOTING_PLUGIN = SchemeCompilerPlugin(
     builder=Builder('openpathsampling.SpringShootingMoveScheme'),
     parameters=[
         NETWORK_PARAMETER,
-        Parameter('k_spring', custom_eval),
-        Parameter('delta_max', custom_eval),
+        Parameter('k_spring', custom_eval,
+                  json_type=json_type_eval("Float"),
+                  description="spring constant for the spring shooting move"),
+        Parameter('delta_max', custom_eval_int_strict_pos,
+                  json_type=json_type_eval("IntStrictPos"),
+                  description=("maximum shift in shooting point (number of "
+                               "frames)"),
+                  ),
         ENGINE_PARAMETER
     ],
     name='spring-shooting',

--- a/paths_cli/compiling/shooting.py
+++ b/paths_cli/compiling/shooting.py
@@ -2,14 +2,24 @@ from paths_cli.compiling.core import (
     InstanceCompilerPlugin, CategoryCompiler, Builder, Parameter
 )
 from paths_cli.compiling.root_compiler import compiler_for
-from paths_cli.compiling.tools import custom_eval
+from paths_cli.compiling.tools import custom_eval_float
 from paths_cli.compiling.plugins import ShootingPointSelectorPlugin
+from paths_cli.compiling.json_type import json_type_ref, json_type_eval
+
+shooting_selector_compiler = compiler_for('shooting-point-selector')
+SP_SELECTOR_PARAMETER = Parameter(
+    'selector', compiler_for('shooting-point-selector'), default=None,
+    json_type=json_type_ref('shooting-point-selector'),
+    description="shooting point selection algorithm to use.",
+)
 
 
 build_uniform_selector = ShootingPointSelectorPlugin(
     builder=Builder('openpathsampling.UniformSelector'),
     parameters=[],
     name='uniform',
+    description=("Uniform shooting point selection probability: all frames "
+                 "have equal probability (endpoints excluded)."),
 )
 
 
@@ -24,11 +34,24 @@ build_gaussian_selector = ShootingPointSelectorPlugin(
     builder=Builder('openpathsampling.GaussianBiasSelector',
                     remapper=_remapping_gaussian_stddev),
     parameters=[
-        Parameter('cv', compiler_for('cv')),
-        Parameter('mean', custom_eval),
-        Parameter('stddev', custom_eval),
+        Parameter('cv', compiler_for('cv'), json_type=json_type_ref('cv'),
+                  description="bias as a Gaussian in this CV"),
+        Parameter('mean', custom_eval_float,
+                  json_type=json_type_eval("Float"),
+                  description="mean of the Gaussian"),
+        Parameter('stddev', custom_eval_float,
+                  json_type=json_type_eval("Float"),
+                  description="standard deviation of the Gaussian"),
     ],
     name='gaussian',
+    description=(
+        "Bias shooting point selection based on a Gaussian. That is, for a "
+        "configuration :math:`x`, the probability of selecting that "
+        "configruation is proportional to "
+        r":math:`\exp(-(\lambda(x)-\bar{\lambda})^2 / (2\sigma^2))`, "
+        r"where :math:`\lambda` is the given CV, :math:`\bar{\lambda}` is "
+        r"the mean, and :math:`\sigma` is the standard deviation."
+    ),
 )
 
 

--- a/paths_cli/compiling/shooting.py
+++ b/paths_cli/compiling/shooting.py
@@ -55,10 +55,3 @@ build_gaussian_selector = ShootingPointSelectorPlugin(
 )
 
 
-# shooting_selector_compiler = CategoryCompiler(
-#     type_dispatch={
-#         'uniform': build_uniform_selector,
-#         'gaussian': build_gaussian_selector,
-#     },
-#     label='shooting-point-selectors'
-# )

--- a/paths_cli/compiling/shooting.py
+++ b/paths_cli/compiling/shooting.py
@@ -3,9 +3,10 @@ from paths_cli.compiling.core import (
 )
 from paths_cli.compiling.root_compiler import compiler_for
 from paths_cli.compiling.tools import custom_eval
+from paths_cli.compiling.plugins import ShootingPointSelectorPlugin
 
 
-build_uniform_selector = InstanceCompilerPlugin(
+build_uniform_selector = ShootingPointSelectorPlugin(
     builder=Builder('openpathsampling.UniformSelector'),
     parameters=[],
     name='uniform',
@@ -19,7 +20,7 @@ def _remapping_gaussian_stddev(dct):
     return dct
 
 
-build_gaussian_selector = InstanceCompilerPlugin(
+build_gaussian_selector = ShootingPointSelectorPlugin(
     builder=Builder('openpathsampling.GaussianBiasSelector',
                     remapper=_remapping_gaussian_stddev),
     parameters=[
@@ -31,10 +32,10 @@ build_gaussian_selector = InstanceCompilerPlugin(
 )
 
 
-shooting_selector_compiler = CategoryCompiler(
-    type_dispatch={
-        'uniform': build_uniform_selector,
-        'gaussian': build_gaussian_selector,
-    },
-    label='shooting-selectors'
-)
+# shooting_selector_compiler = CategoryCompiler(
+#     type_dispatch={
+#         'uniform': build_uniform_selector,
+#         'gaussian': build_gaussian_selector,
+#     },
+#     label='shooting-point-selectors'
+# )

--- a/paths_cli/compiling/strategies.py
+++ b/paths_cli/compiling/strategies.py
@@ -1,12 +1,10 @@
 from paths_cli.compiling.core import Builder, Parameter
-# from paths_cli.compiling.shooting import shooting_selector_compiler
 from paths_cli.compiling.plugins import (
     StrategyCompilerPlugin, CategoryPlugin
 )
 from paths_cli.compiling.root_compiler import compiler_for
 from paths_cli.compiling.json_type import json_type_ref
-
-shooting_selector_compiler = compiler_for('shooting-point-selector')
+from paths_cli.compiling.shooting import SP_SELECTOR_PARAMETER
 
 
 def _strategy_name(class_name):
@@ -19,8 +17,6 @@ def _group_parameter(group_name):
 
 
 # TODO: maybe this moves into shooting once we have the metadata?
-SP_SELECTOR_PARAMETER = Parameter('selector', shooting_selector_compiler,
-                                  default=None)
 
 ENGINE_PARAMETER = Parameter(
     'engine', compiler_for('engine'), json_type=json_type_ref('engine'),

--- a/paths_cli/compiling/strategies.py
+++ b/paths_cli/compiling/strategies.py
@@ -12,7 +12,7 @@ def _strategy_name(class_name):
 
 
 def _group_parameter(group_name):
-    return Parameter('group', str, default=group_name,
+    return Parameter('group', str, json_type="string", default=group_name,
                      description="the group name for these movers")
 
 
@@ -29,8 +29,16 @@ SHOOTING_GROUP_PARAMETER = _group_parameter('shooting')
 REPEX_GROUP_PARAMETER = _group_parameter('repex')
 MINUS_GROUP_PARAMETER = _group_parameter('minus')
 
-REPLACE_TRUE_PARAMETER = Parameter('replace', bool, default=True)
-REPLACE_FALSE_PARAMETER = Parameter('replace', bool, default=False)
+REPLACE_TRUE_PARAMETER = Parameter(
+    'replace', bool, json_type="bool", default=True,
+    description=("whether this should replace existing objects (default "
+                 "True)")
+)
+REPLACE_FALSE_PARAMETER = Parameter(
+    'replace', bool, json_type="bool", default=False,
+    description=("whether this should replace existing objects (default "
+                 "False)")
+)
 
 
 ONE_WAY_SHOOTING_STRATEGY_PLUGIN = StrategyCompilerPlugin(

--- a/paths_cli/compiling/strategies.py
+++ b/paths_cli/compiling/strategies.py
@@ -71,8 +71,8 @@ build_nearest_neighbor_repex_strategy = StrategyCompilerPlugin(
         REPLACE_TRUE_PARAMETER
     ],
     name='nearest-neighbor-repex',
-    description=("Use replica exchange only between neearest-neighbor "
-                 "interfaces in this move scheme"),
+    description=("Use replica exchange only between nearest-neighbor "
+                 "interfaces in this move scheme."),
 )
 
 build_all_set_repex_strategy = StrategyCompilerPlugin(

--- a/paths_cli/compiling/strategies.py
+++ b/paths_cli/compiling/strategies.py
@@ -48,6 +48,7 @@ ONE_WAY_SHOOTING_STRATEGY_PLUGIN = StrategyCompilerPlugin(
         REPLACE_TRUE_PARAMETER
     ],
     name='one-way-shooting',
+    description="Use one-way-shooting moves in this move scheme.",
 )
 build_one_way_shooting_strategy = ONE_WAY_SHOOTING_STRATEGY_PLUGIN
 
@@ -70,6 +71,8 @@ build_nearest_neighbor_repex_strategy = StrategyCompilerPlugin(
         REPLACE_TRUE_PARAMETER
     ],
     name='nearest-neighbor-repex',
+    description=("Use replica exchange only between neearest-neighbor "
+                 "interfaces in this move scheme"),
 )
 
 build_all_set_repex_strategy = StrategyCompilerPlugin(
@@ -79,6 +82,8 @@ build_all_set_repex_strategy = StrategyCompilerPlugin(
         REPLACE_TRUE_PARAMETER
     ],
     name='all-set-repex',
+    description=("Use replica exchange allowing swap attempts between any "
+                 "pair of ensembles within the same interface set."),
 )
 
 build_path_reversal_strategy = StrategyCompilerPlugin(
@@ -88,6 +93,7 @@ build_path_reversal_strategy = StrategyCompilerPlugin(
         REPLACE_TRUE_PARAMETER,
     ],
     name='path-reversal',
+    description="Use path reversal moves in this move scheme.",
 )
 
 build_minus_move_strategy = StrategyCompilerPlugin(
@@ -98,6 +104,9 @@ build_minus_move_strategy = StrategyCompilerPlugin(
         REPLACE_TRUE_PARAMETER,
     ],
     name='minus',
+    description=("Use the minus move in this move scheme. This strategy "
+                 "uses the M-shaped, or multiple interface set minus "
+                 "move, and always keeps a sample in the minus interface."),
 )
 
 build_single_replica_minus_move_strategy = StrategyCompilerPlugin(
@@ -108,6 +117,12 @@ build_single_replica_minus_move_strategy = StrategyCompilerPlugin(
         REPLACE_TRUE_PARAMETER,
     ],
     name='single-replica-minus',
+    description=("Use the single-replica minus move in this move scheme. "
+                 "This strategy does not keep a replica in the minus "
+                 "ensemble; instead, that trajectory is only temporarily "
+                 "created during this move. This should not be used if "
+                 "there are multiple interface sets with the same initial "
+                 "state."),
 )
 
 STRATEGY_COMPILER = CategoryPlugin(StrategyCompilerPlugin,

--- a/paths_cli/compiling/strategies.py
+++ b/paths_cli/compiling/strategies.py
@@ -1,10 +1,12 @@
 from paths_cli.compiling.core import Builder, Parameter
-from paths_cli.compiling.shooting import shooting_selector_compiler
+# from paths_cli.compiling.shooting import shooting_selector_compiler
 from paths_cli.compiling.plugins import (
     StrategyCompilerPlugin, CategoryPlugin
 )
 from paths_cli.compiling.root_compiler import compiler_for
 from paths_cli.compiling.json_type import json_type_ref
+
+shooting_selector_compiler = compiler_for('shooting-point-selector')
 
 
 def _strategy_name(class_name):

--- a/paths_cli/compiling/tools.py
+++ b/paths_cli/compiling/tools.py
@@ -33,6 +33,11 @@ def custom_eval_int_strict_pos(obj, named_objs=None):
     return val
 
 
+def custom_eval_float(obj, named_objs=None):
+    val = custom_eval(obj, named_objs)
+    return float(val)
+
+
 class UnknownAtomsError(RuntimeError):
     pass
 

--- a/paths_cli/compiling/volumes.py
+++ b/paths_cli/compiling/volumes.py
@@ -2,7 +2,7 @@ import operator
 import functools
 
 from paths_cli.compiling.core import Parameter
-from paths_cli.compiling.tools import custom_eval
+from paths_cli.compiling.tools import custom_eval_float
 from paths_cli.compiling.plugins import VolumeCompilerPlugin, CategoryPlugin
 from paths_cli.compiling.root_compiler import compiler_for
 from paths_cli.compiling.json_type import (
@@ -30,10 +30,10 @@ CV_VOLUME_PLUGIN = VolumeCompilerPlugin(
     parameters=[
         Parameter('cv', compiler_for('cv'), json_type=json_type_ref('cv'),
                   description="CV that defines this volume"),
-        Parameter('lambda_min', custom_eval,
+        Parameter('lambda_min', custom_eval_float,
                   json_type=json_type_eval("Float"),
                   description="Lower bound for this volume"),
-        Parameter('lambda_max', custom_eval,
+        Parameter('lambda_max', custom_eval_float,
                   json_type=json_type_eval("Float"),
                   description="Upper bound for this volume")
     ],

--- a/paths_cli/compiling/volumes.py
+++ b/paths_cli/compiling/volumes.py
@@ -5,7 +5,9 @@ from paths_cli.compiling.core import Parameter
 from paths_cli.compiling.tools import custom_eval
 from paths_cli.compiling.plugins import VolumeCompilerPlugin, CategoryPlugin
 from paths_cli.compiling.root_compiler import compiler_for
-from paths_cli.compiling.json_type import json_type_ref
+from paths_cli.compiling.json_type import (
+    json_type_ref, json_type_eval, json_type_list
+)
 
 
 # TODO: extra function for volumes should not be necessary as of OPS 2.0
@@ -29,20 +31,18 @@ CV_VOLUME_PLUGIN = VolumeCompilerPlugin(
         Parameter('cv', compiler_for('cv'), json_type=json_type_ref('cv'),
                   description="CV that defines this volume"),
         Parameter('lambda_min', custom_eval,
+                  json_type=json_type_eval("Float"),
                   description="Lower bound for this volume"),
         Parameter('lambda_max', custom_eval,
+                  json_type=json_type_eval("Float"),
                   description="Upper bound for this volume")
     ],
+    description=("A volume defined by an allowed range of values for the "
+                 "given CV."),
     name='cv-volume',
 )
 
 build_cv_volume = CV_VOLUME_PLUGIN
-
-# jsonschema type for combination volumes
-VOL_ARRAY_TYPE = {
-    'type': 'array',
-    'items': json_type_ref('volume'),
-}
 
 
 INTERSECTION_VOLUME_PLUGIN = VolumeCompilerPlugin(
@@ -50,9 +50,12 @@ INTERSECTION_VOLUME_PLUGIN = VolumeCompilerPlugin(
                                                 subvolumes),
     parameters=[
         Parameter('subvolumes', compiler_for('volume'),
-                  json_type=VOL_ARRAY_TYPE,
+                  json_type=json_type_list(json_type_ref('volume')),
                   description="List of the volumes to intersect")
     ],
+    description=("A volume determined by the intersection of its "
+                 "constituent volumes; i.e., to be in this volume a point "
+                 "must be in *all* the constituent volumes."),
     name='intersection',
 )
 
@@ -64,9 +67,12 @@ UNION_VOLUME_PLUGIN = VolumeCompilerPlugin(
                                                 subvolumes),
     parameters=[
         Parameter('subvolumes', compiler_for('volume'),
-                  json_type=VOL_ARRAY_TYPE,
+                  json_type=json_type_list(json_type_ref('volume')),
                   description="List of the volumes to join into a union")
     ],
+    description=("A volume defined by the union of its constituent "
+                 "volumes; i.e., a point that is in *any* of the "
+                 "constituent volumes is also in this volume."),
     name='union',
 )
 

--- a/paths_cli/tests/compiling/test_root_compiler.py
+++ b/paths_cli/tests/compiling/test_root_compiler.py
@@ -149,6 +149,16 @@ def test_get_compiler_nonexisting(foo_compiler):
         assert 'foo' in _COMPILERS
 
 
+def test_get_compiler_none():
+    # if trying to get the None compiler, the same None compiler should
+    # always be returned
+    with patch.dict(COMPILER_LOC, {}):
+        compiler1 = _get_compiler(None)
+        assert compiler1.label is None
+        compiler2 = _get_compiler(None)
+        assert compiler1 is compiler2
+
+
 def test_get_compiler_nonstandard_name_multiple():
     # regression test based on real issue -- there was an error where
     # non-canonical names (e.g., names that involved hyphens instead of

--- a/paths_cli/tests/compiling/test_root_compiler.py
+++ b/paths_cli/tests/compiling/test_root_compiler.py
@@ -20,21 +20,25 @@ from paths_cli.compiling.plugins import CategoryPlugin
 def foo_compiler():
     return CategoryCompiler(None, 'foo')
 
+
 @pytest.fixture
 def foo_compiler_plugin():
     return CategoryPlugin(Mock(category='foo', __name__='foo'), ['bar'])
 
+
 @pytest.fixture
 def foo_baz_builder_plugin():
-    builder = InstanceCompilerPlugin(lambda: "FOO" , [], name='baz',
+    builder = InstanceCompilerPlugin(lambda: "FOO", [], name='baz',
                                      aliases=['qux'])
     builder.category = 'foo'
     return builder
+
 
 ### CONSTANTS ##############################################################
 
 COMPILER_LOC = "paths_cli.compiling.root_compiler._COMPILERS"
 BASE = "paths_cli.compiling.root_compiler."
+
 
 ### TESTS ##################################################################
 
@@ -43,6 +47,7 @@ BASE = "paths_cli.compiling.root_compiler."
 def test_clean_input_key(input_string):
     assert clean_input_key(input_string) == "foo_bar"
 
+
 @pytest.mark.parametrize('input_name', ['canonical', 'alias'])
 def test_canonical_name(input_name):
     compilers = {'canonical': "FOO"}
@@ -50,6 +55,7 @@ def test_canonical_name(input_name):
     with patch.dict(COMPILER_LOC, compilers) as compilers_, \
             patch.dict(BASE + "_ALIASES", aliases) as aliases_:
         assert _canonical_name(input_name) == "canonical"
+
 
 class TestCategoryCompilerProxy:
     def setup(self):
@@ -86,6 +92,7 @@ class TestCategoryCompilerProxy:
         with patch.dict(COMPILER_LOC, {'foo': foo_compiler}):
             assert proxy(user_input) == "bazbaz"
 
+
 def test_compiler_for_nonexisting():
     # if nothing is ever registered with the compiler, then compiler_for
     # should error
@@ -97,6 +104,7 @@ def test_compiler_for_nonexisting():
         with pytest.raises(RuntimeError, match="No CategoryCompiler"):
             proxy._proxy
 
+
 def test_compiler_for_existing(foo_compiler):
     # if a compiler already exists when compiler_for is called, then
     # compiler_for should get that as its proxy
@@ -104,12 +112,14 @@ def test_compiler_for_existing(foo_compiler):
         proxy = compiler_for('foo')
         assert proxy._proxy is foo_compiler
 
+
 def test_compiler_for_unregistered(foo_compiler):
     # if a compiler is registered after compiler_for is called, then
     # compiler_for should use that as its proxy
     proxy = compiler_for('foo')
     with patch.dict(COMPILER_LOC, {'foo': foo_compiler}):
         assert proxy._proxy is foo_compiler
+
 
 def test_compiler_for_registered_alias(foo_compiler):
     # if compiler_for is registered as an alias, compiler_for should still
@@ -121,11 +131,13 @@ def test_compiler_for_registered_alias(foo_compiler):
         proxy  = compiler_for('bar')
         assert proxy._proxy is foo_compiler
 
+
 def test_get_compiler_existing(foo_compiler):
     # if a compiler has been registered, then _get_compiler should return the
     # registered compiler
     with patch.dict(COMPILER_LOC, {'foo': foo_compiler}):
         assert _get_compiler('foo') is foo_compiler
+
 
 def test_get_compiler_nonexisting(foo_compiler):
     # if a compiler has not been registered, then _get_compiler should create
@@ -135,6 +147,18 @@ def test_get_compiler_nonexisting(foo_compiler):
         assert compiler is not foo_compiler  # overkill
         assert compiler.label == 'foo'
         assert 'foo' in _COMPILERS
+
+
+def test_get_compiler_nonstandard_name_multiple():
+    # regression test based on real issue -- there was an error where
+    # non-canonical names (e.g., names that involved hyphens instead of
+    # underscores) would overwrite the previously created compiler instead
+    # of getting the identical object
+    with patch.dict(COMPILER_LOC, {}):
+        c1 = _get_compiler('non-canonical-name')
+        c2 = _get_compiler('non-canonical-name')
+        assert c1 is c2
+
 
 @pytest.mark.parametrize('canonical,aliases,expected', [
     ('foo', ['bar', 'baz'], ['foo', 'bar', 'baz']),
@@ -149,6 +173,7 @@ def test_get_registration_names(canonical, aliases, expected):
     type(plugin).name = PropertyMock(return_value=canonical)
     assert _get_registration_names(plugin) == expected
 
+
 def test_register_compiler_plugin(foo_compiler_plugin):
     # _register_compiler_plugin should register compilers that don't exist
     compilers = {}
@@ -161,6 +186,7 @@ def test_register_compiler_plugin(foo_compiler_plugin):
         assert 'bar' in _ALIASES
 
     assert 'foo' not in _COMPILERS
+
 
 @pytest.mark.parametrize('duplicate_of', ['canonical', 'alias'])
 @pytest.mark.parametrize('duplicate_from', ['canonical', 'alias'])
@@ -184,6 +210,7 @@ def test_register_compiler_plugin_duplicate(duplicate_of, duplicate_from):
         with pytest.raises(CategoryCompilerRegistrationError):
             _register_compiler_plugin(plugin)
 
+
 @pytest.mark.parametrize('compiler_exists', [True, False])
 def test_register_builder_plugin(compiler_exists, foo_baz_builder_plugin,
                                  foo_compiler):
@@ -203,6 +230,7 @@ def test_register_builder_plugin(compiler_exists, foo_baz_builder_plugin,
         assert type_dispatch['baz'] is foo_baz_builder_plugin
         assert type_dispatch['qux'] is foo_baz_builder_plugin
 
+
 def test_register_plugins_unit(foo_compiler_plugin, foo_baz_builder_plugin):
     # register_plugins should correctly sort builder and compiler plugins,
     # and call the correct registration functions
@@ -211,6 +239,7 @@ def test_register_plugins_unit(foo_compiler_plugin, foo_baz_builder_plugin):
         register_plugins([foo_baz_builder_plugin, foo_compiler_plugin])
         assert builder.called_once_with(foo_baz_builder_plugin)
         assert compiler.called_once_with(foo_compiler_plugin)
+
 
 def test_register_plugins_integration(foo_compiler_plugin,
                                       foo_baz_builder_plugin):
@@ -224,6 +253,7 @@ def test_register_plugins_integration(foo_compiler_plugin,
         assert 'foo' in _COMPILERS
         type_dispatch = _COMPILERS['foo'].type_dispatch
         assert type_dispatch['baz'] is foo_baz_builder_plugin
+
 
 def test_sort_user_categories():
     # sorted user categories should match the expected compile order
@@ -244,6 +274,7 @@ def test_sort_user_categories():
         paths_cli.compiling.root_compiler.COMPILE_ORDER = COMPILE_ORDER
         # check that we unset properly (test the test)
         assert paths_cli.compiling.root_compiler.COMPILE_ORDER[0] == 'engine'
+
 
 def test_do_compile():
     # compiler should correctly compile a basic input dict


### PR DESCRIPTION
This PR will clean up the `compiling` subpackage such that the `gendocs` script creates complete and suitable documentation for the built-in plugins. This primarily involves adding descriptions and type information.