### PR TITLE
Stop excluding tests from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,5 @@
 [report]
 omit =
-    */paths_cli/tests/*
     */paths_cli/_installed_version.py
     */paths_cli/version.py
 exclude_lines =

--- a/paths_cli/compiling/core.py
+++ b/paths_cli/compiling/core.py
@@ -153,7 +153,7 @@ class InstanceCompilerPlugin(OPSPlugin):
     """
     SCHEMA = "http://openpathsampling.org/schemas/sim-setup/draft01.json"
     category = None
-    
+
     def __init__(self, builder, parameters, name=None, *, aliases=None,
                  description=None, requires_ops=(1, 0),
                  requires_cli=(0, 3)):

--- a/paths_cli/tests/commands/test_md.py
+++ b/paths_cli/tests/commands/test_md.py
@@ -159,7 +159,7 @@ def test_md_main(md_fixture, inp):
             nsteps, ensembles = 5, None
         elif inp == 'ensemble':
             nsteps, ensembles = None, [ens]
-        else:
+        else:  # -no-cov-
             raise RuntimeError("pytest went crazy")
 
         traj, foo = md_main(

--- a/paths_cli/tests/commands/utils.py
+++ b/paths_cli/tests/commands/utils.py
@@ -1,7 +1,7 @@
 import traceback
 
 def assert_click_success(result):
-    if result.exit_code != 0:
+    if result.exit_code != 0:  # -no-cov-  (only occurs on test error)
         print(result.output)
         traceback.print_tb(result.exc_info[2])
         print(result.exc_info[0], result.exc_info[1])

--- a/paths_cli/tests/compiling/test_core.py
+++ b/paths_cli/tests/compiling/test_core.py
@@ -332,7 +332,7 @@ class TestCategoryCompiler:
             assert obj == 'bar'
         elif input_type == 'dict':
             assert obj.data == 'qux'
-        else:
+        else:  # -no-cov-
             raise RuntimeError("Error in test setup")
 
     @pytest.mark.parametrize('input_type', ['str', 'dict'])

--- a/paths_cli/tests/test_file_copying.py
+++ b/paths_cli/tests/test_file_copying.py
@@ -59,7 +59,8 @@ class TestPrecompute(object):
                 self.previously_seen = set([])
 
             def __call__(self, snap):
-                if snap in self.previously_seen:
+                if snap in self.previously_seen:  # -no-cov-
+                    # this is only covered if an error occurs
                     raise AssertionError("Second CV eval for " + str(snap))
                 self.previously_seen.update({snap})
                 return snap.xyz[0][0]

--- a/paths_cli/tests/test_parameters.py
+++ b/paths_cli/tests/test_parameters.py
@@ -103,7 +103,7 @@ class ParamInstanceTest(object):
 
     def create_file(self, getter):
         filename = self._filename(getter)
-        if getter == "named":
+        if getter == "name":
             self.other_scheme = self.other_scheme.named("other")
             self.other_engine = self.other_engine.named("other")
 

--- a/paths_cli/tests/test_utils.py
+++ b/paths_cli/tests/test_utils.py
@@ -10,7 +10,7 @@ class TestOrderedSet:
     def test_empty(self):
         ordered = OrderedSet()
         assert len(ordered) == 0
-        for _ in ordered:
+        for _ in ordered:  # -no-cov-
             raise RuntimeError("This should not happen")
 
     def test_order(self):

--- a/paths_cli/tests/utils.py
+++ b/paths_cli/tests/utils.py
@@ -3,13 +3,13 @@ import pytest
 
 try:
     urllib.request.urlopen('https://www.google.com')
-except:
+except:  # -no-cov-
     HAS_INTERNET = False
 else:
     HAS_INTERNET = True
 
 def assert_url(url):
-    if not HAS_INTERNET:
+    if not HAS_INTERNET:  # -no-cov-
         pytest.skip("Internet connection seems faulty")
 
     # TODO: On a 404 this will raise a urllib.error.HTTPError. It would be

--- a/paths_cli/tests/wizard/mock_wizard.py
+++ b/paths_cli/tests/wizard/mock_wizard.py
@@ -30,7 +30,9 @@ class MockConsole:
         self.input_call_count += 1
         try:
             user_input = next(self._input_iter)
-        except StopIteration as e:
+        except StopIteration as e:  # -no-cov-
+            # this only occurs on a test error and provides diagnostic
+            # information
             print(self.log_text)
             raise e
 

--- a/paths_cli/tests/wizard/test_load_from_ops.py
+++ b/paths_cli/tests/wizard/test_load_from_ops.py
@@ -25,7 +25,7 @@ class FakeStore:
             return self._objects[key]
         elif isinstance(key, str):
             return self._named_objects[key]
-        else:
+        else:  # -nocov-
             raise TypeError("Huh?")
 
     def __iter__(self):

--- a/paths_cli/tests/wizard/test_load_from_ops.py
+++ b/paths_cli/tests/wizard/test_load_from_ops.py
@@ -20,13 +20,15 @@ class FakeStore:
         self._objects = objects
         self._named_objects = {obj.name: obj for obj in objects}
 
-    def __getitem__(self, key):
-        if isinstance(key, int):
-            return self._objects[key]
-        elif isinstance(key, str):
-            return self._named_objects[key]
-        else:  # -nocov-
-            raise TypeError("Huh?")
+    # leaving this commented out... it doesn't seem to be used currently,
+    # but if it is needed in the future, this should be the implementation
+    # def __getitem__(self, key):
+    #     if isinstance(key, int):
+    #         return self._objects[key]
+    #     elif isinstance(key, str):
+    #         return self._named_objects[key]
+    #     else:  # -no-cov-
+    #         raise TypeError("Huh?")
 
     def __iter__(self):
         return iter(self._objects)

--- a/paths_cli/tests/wizard/test_parameters.py
+++ b/paths_cli/tests/wizard/test_parameters.py
@@ -15,16 +15,12 @@ class TestWizardParameter:
     def _reverse(string):
         return "".join(reversed(string))
 
-    @staticmethod
-    def _summarize(string):
-        return f"Here's a summary: we made {string}"
-
     def setup(self):
         self.parameter = WizardParameter(
             name='foo',
             ask="How should I {do_what}?",
             loader=self._reverse,
-            summarize=self._summarize,
+            summarize=lambda string: f"Should be unused. Input: {string}",
         )
         self.wizard = mock_wizard(["bar"])
         self.compiler_plugin = compiling.InstanceCompilerPlugin(

--- a/paths_cli/tests/wizard/test_volumes.py
+++ b/paths_cli/tests/wizard/test_volumes.py
@@ -16,15 +16,6 @@ from openpathsampling.experimental.storage.collective_variables import \
 from openpathsampling.tests.test_helpers import make_1d_traj
 
 
-def _wrap(x, period_min, period_max):
-    # used in testing periodic CVs
-    while x >= period_max:
-        x -= period_max - period_min
-    while x < period_min:
-        x += period_max - period-min
-    return x
-
-
 @pytest.fixture
 def volume_setup():
     cv = CoordinateFunctionCV(lambda snap: snap.xyz[0][0]).named('x')
@@ -120,8 +111,7 @@ def test_cv_defined_volume(periodic):
         min_ = 0.0
         max_ = 1.0
         cv = CoordinateFunctionCV(
-            lambda snap: _wrap(snap.xyz[0][0], period_min=min_,
-                               period_max=max_),
+            lambda snap: snap.xyz[0][0],
             period_min=min_, period_max=max_
         ).named('x')
         inputs = ['x', '0.75', '1.25']

--- a/paths_cli/tests/wizard/test_volumes.py
+++ b/paths_cli/tests/wizard/test_volumes.py
@@ -54,7 +54,7 @@ def test_volume_intro(as_state, has_state):
         assert "You'll need to define" in intro
     elif not as_state:
         assert intro == _VOL_DESC
-    else:
+    else:  # -no-cov-
         raise RuntimeError("WTF?")
 
 def _binary_volume_test(volume_setup, func):

--- a/paths_cli/tests/wizard/test_wizard.py
+++ b/paths_cli/tests/wizard/test_wizard.py
@@ -309,6 +309,7 @@ class TestWizard:
         assert len(storage.networks) == len(storage.schemes) == 0
         assert len(storage.engines) == 1
         assert storage.engines[toy_engine.name] == toy_engine
+        assert storage.engines[0] == toy_engine
         assert "Everything has been stored" in self.wizard.console.log_text
 
     @pytest.mark.parametrize('req,count,expected', [
@@ -382,6 +383,7 @@ class TestWizard:
         assert len(storage.networks) == len(storage.schemes) == 0
         assert len(storage.engines) == 1
         assert storage.engines[toy_engine.name] == toy_engine
+        assert storage.engines[0] == toy_engine
 
     def test_run_wizard_quit(self):
         console = MockConsole()


### PR DESCRIPTION
Back in March, I saw a tweet from Ned Batchelder linking to this:

https://nedbatchelder.com/blog/202008/you_should_include_your_tests_in_coverage.html

Since then, I've been considering including test suites in coverage. This PR adds the test suite to the coverage data. Consider this a proposal, because I'm not necessarily wedded to the idea we have to do this. But please read Ned's blog post, and consider if doing this affects your workflow in any way.

My own thoughts on the concerns Ned's post mentions:

* **It skews my results**: This is part of why I don't do it on the OPS library (because we should be ashamed of low coverage! 80% is shame in a way 90% is not!) However, on packages that already have 100% coverage, there's nothing to skew -- so I'm in favor of including tests in coverage here.
* **It clutters the output**: I mainly look at coverage via CodeCov's web interface now (or, locally, I restrict coverage output to a certain subset of files). In CodeCov, it's easy enough for the get past the whole tests/ directory either in sunburst or in file browser mode (the two I typically use).
* **I don't intend to run all the tests**: I don't see this as an issue. When running coverage locally, it's easy enough for my to only look at coverage of the files I'm interested in. When working on a subpackage (e.g., the wizard) I check coverage locally by only running the tests for that package and only generating coverage for that package (`pytest --cov=paths_cli/wizard paths_cli/tests/wizard/`).

The only other issue I see is that I consider "non-test statements" to be a good figure for a minimal lines-of-code estimate. This number is trivial to get from the current setup. It's a little harder to get if test are included in coverage (need to click on the tests/ directory in the file browser view of  CodeCov, then at the bottom do the math on "Project totals - Folder totals"). I think Ned's arguments in favor including tests in coverage outweigh this minor inconvenience. It looks like this points out a few corners of code that are missing coverage, so it might be worth it. (There are also areas that probably can be ignored in coverage, like `RuntimeError('pytest went crazy')`).

If there's general support for this approach, I'll move forward with bringing this PR back up to 100% coverage.