### PR TITLE
Fix error in output for contents

### DIFF
--- a/paths_cli/commands/contents.py
+++ b/paths_cli/commands/contents.py
@@ -37,7 +37,12 @@ def contents(input_file, table):
     command (i.e., to identify exactly how a state or engine is named.)
     """
     storage = INPUT_FILE.get(input_file)
-    print(storage)
+    try:
+        print(storage.filename)
+    except AttributeError:
+        # TODO: this should be removed once SimStore has a `filename`
+        # attribute
+        print(storage)
     if table is None:
         report_all_tables(storage)
     else:

--- a/paths_cli/commands/contents.py
+++ b/paths_cli/commands/contents.py
@@ -39,7 +39,7 @@ def contents(input_file, table):
     storage = INPUT_FILE.get(input_file)
     try:
         print(storage.filename)
-    except AttributeError:
+    except AttributeError:  # no-cov  (temporary fix)
         # TODO: this should be removed once SimStore has a `filename`
         # attribute
         print(storage)

--- a/paths_cli/tests/commands/test_contents.py
+++ b/paths_cli/tests/commands/test_contents.py
@@ -22,7 +22,7 @@ def test_contents(tps_fixture):
         results = runner.invoke(contents, ['setup.nc'])
         cwd = os.getcwd()
         expected = [
-            f"Storage @ '{cwd}/setup.nc'",
+            f"{cwd}/setup.nc",
             "CVs: 1 item", "* x",
             "Volumes: 8 items", "* A", "* B", "* plus 6 unnamed items",
             "Engines: 2 items", "* flat", "* plus 1 unnamed item",
@@ -56,17 +56,17 @@ def test_contents_table(tps_fixture, table):
         cwd = os.getcwd()
         expected = {
             'volumes': [
-                f"Storage @ '{cwd}/setup.nc'",
+                f"{cwd}/setup.nc",
                 "volumes: 8 items", "* A", "* B", "* plus 6 unnamed items",
                 ""
             ],
             'trajectories': [
-                f"Storage @ '{cwd}/setup.nc'",
+                f"{cwd}/setup.nc",
                 "trajectories: 1 unnamed item",
                 ""
             ],
             'tags': [
-                f"Storage @ '{cwd}/setup.nc'",
+                f"{cwd}/setup.nc",
                 "tags: 1 item",
                 "* initial_conditions",
                 ""


### PR DESCRIPTION
This is a better solution for #71 (should replace #72).

We really don't want all that junk in the `contents` output anyway. The purpose of that line to give the filename as part of the output, so let's just give the filename.