### PR TITLE
Fix CI problems

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -70,6 +70,8 @@ jobs:
         run: |
           python -c "import paths_cli"
           py.test -vv --cov --cov-report xml:cov.xml
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v4
         with:
           files: ./cov.xml
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -24,12 +24,12 @@ jobs:
     strategy:
       matrix:
         CONDA_PY:
-          - 3.9
-          - 3.8
-          - 3.7
+          - "3.11"
+          - "3.10"
+          - "3.9"
         INTEGRATIONS: [""]
         include:
-          - CONDA_PY: 3.9
+          - CONDA_PY: "3.11"
             INTEGRATIONS: 'all-optionals'
 
     steps:

--- a/paths_cli/tests/commands/test_md.py
+++ b/paths_cli/tests/commands/test_md.py
@@ -12,7 +12,7 @@ from openpathsampling.tests.test_helpers import \
         make_1d_traj, CalvinistDynamics
 
 class TestProgressReporter(object):
-    def setup(self):
+    def setup_method(self):
         self.progress = ProgressReporter(timestep=None, update_freq=5)
 
     @pytest.mark.parametrize('timestep', [None, 0.1])
@@ -38,7 +38,7 @@ class TestProgressReporter(object):
             assert out == ""
 
 class TestEnsembleSatisfiedContinueConditions(object):
-    def setup(self):
+    def setup_method(self):
         cv = paths.CoordinateFunctionCV('x', lambda x: x.xyz[0][0])
         vol_A = paths.CVDefinedVolume(cv, float("-inf"), 0.0)
         vol_B = paths.CVDefinedVolume(cv, 1.0, float("inf"))

--- a/paths_cli/tests/compiling/_gendocs/test_docs_generator.py
+++ b/paths_cli/tests/compiling/_gendocs/test_docs_generator.py
@@ -9,7 +9,7 @@ from paths_cli.compiling import Parameter, InstanceCompilerPlugin
 from paths_cli.compiling.core import CategoryCompiler
 
 class TestDocsGenerator:
-    def setup(self):
+    def setup_method(self):
         self.required_parameter = Parameter(
             name="req_param",
             loader=None,

--- a/paths_cli/tests/compiling/test_core.py
+++ b/paths_cli/tests/compiling/test_core.py
@@ -25,7 +25,7 @@ def mock_named_object_factory(dct):
 
 
 class TestParameter:
-    def setup(self):
+    def setup_method(self):
         self.loader = Mock(
             return_value='foo',
             json_type='string',
@@ -131,7 +131,7 @@ class TestInstanceCompilerPlugin:
     def _builder(req_param, opt_default=10, opt_override=100):
         return f"{req_param}, {opt_default}, {opt_override}"
 
-    def setup(self):
+    def setup_method(self):
         identity = lambda x: x
         self.parameters = [
             Parameter('req_param', identity, json_type="string"),
@@ -227,7 +227,7 @@ class TestInstanceCompilerPlugin:
 
 
 class TestCategoryCompiler:
-    def setup(self):
+    def setup_method(self):
         self.compiler = CategoryCompiler(
             {'foo': mock_named_object_factory},
             'foo_compiler'

--- a/paths_cli/tests/compiling/test_cvs.py
+++ b/paths_cli/tests/compiling/test_cvs.py
@@ -15,7 +15,7 @@ from paths_cli.compat.openmm import HAS_OPENMM
 
 
 class TestMDTrajFunctionCV:
-    def setup(self):
+    def setup_method(self):
         self.ad_pdb = data_filename("ala_small_traj.pdb")
         self.yml = "\n".join([
             "name: phi", "type: mdtraj", "topology: " + self.ad_pdb,

--- a/paths_cli/tests/compiling/test_engines.py
+++ b/paths_cli/tests/compiling/test_engines.py
@@ -12,7 +12,7 @@ from openpathsampling.engines import openmm as ops_openmm
 import mdtraj as md
 
 class TestOpenMMEngineBuilder(object):
-    def setup(self):
+    def setup_method(self):
         self.cwd = os.getcwd()
         self.yml = "\n".join([
             "type: openmm", "name: engine", "system: system.xml",
@@ -20,7 +20,7 @@ class TestOpenMMEngineBuilder(object):
             "n_steps_per_frame: 10", "n_frames_max: 10000"
         ])
 
-    def teardown(self):
+    def teardown_method(self):
         os.chdir(self.cwd)
 
     def _create_files(self, tmpdir):

--- a/paths_cli/tests/compiling/test_plugins.py
+++ b/paths_cli/tests/compiling/test_plugins.py
@@ -3,7 +3,7 @@ from paths_cli.compiling.plugins import *
 from unittest.mock import Mock
 
 class TestCompilerPlugin:
-    def setup(self):
+    def setup_method(self):
         self.plugin_class = Mock(category='foo')
         self.plugin = CategoryPlugin(self.plugin_class)
         self.aliased_plugin = CategoryPlugin(self.plugin_class,

--- a/paths_cli/tests/compiling/test_root_compiler.py
+++ b/paths_cli/tests/compiling/test_root_compiler.py
@@ -58,7 +58,7 @@ def test_canonical_name(input_name):
 
 
 class TestCategoryCompilerProxy:
-    def setup(self):
+    def setup_method(self):
         self.compiler = CategoryCompiler(None, "foo")
         self.compiler.named_objs['bar'] = 'baz'
         self.proxy = _CategoryCompilerProxy('foo')

--- a/paths_cli/tests/compiling/test_volumes.py
+++ b/paths_cli/tests/compiling/test_volumes.py
@@ -14,7 +14,7 @@ from openpathsampling.tests.test_helpers import make_1d_traj
 from paths_cli.compiling.volumes import *
 
 class TestBuildCVVolume:
-    def setup(self):
+    def setup_method(self):
         self.yml = "\n".join(["type: cv-volume", "cv: {func}",
                               "lambda_min: 0", "lambda_max: 1"])
 
@@ -90,7 +90,7 @@ class TestBuildCVVolume:
 
 
 class TestBuildCombinationVolume:
-    def setup(self):
+    def setup_method(self):
         from  openpathsampling.experimental.storage.collective_variables \
                 import CollectiveVariable
         self.cv = CollectiveVariable(lambda s: s.xyz[0][0]).named('foo')

--- a/paths_cli/tests/test_cli.py
+++ b/paths_cli/tests/test_cli.py
@@ -7,7 +7,7 @@ from .null_command import NullCommandContext
 
 
 class TestOpenPathSamplingCLI(object):
-    def setup(self):
+    def setup_method(self):
         def make_mock(name, helpless=False, return_val=None):
             if return_val is None:
                 return_val = name

--- a/paths_cli/tests/test_file_copying.py
+++ b/paths_cli/tests/test_file_copying.py
@@ -11,7 +11,7 @@ from openpathsampling.tests.test_helpers import make_1d_traj
 from paths_cli.file_copying import *
 
 class Test_PRECOMPUTE_CVS(object):
-    def setup(self):
+    def setup_method(self):
         self.tmpdir = tempfile.mkdtemp()
         self.storage_filename = os.path.join(self.tmpdir, "test.nc")
         self.storage = paths.Storage(self.storage_filename, mode='w')
@@ -21,7 +21,7 @@ class Test_PRECOMPUTE_CVS(object):
         self.cv_y = paths.CoordinateFunctionCV("y", lambda s: s.xyz[0][1])
         self.storage.save([self.cv_x, self.cv_y])
 
-    def teardown(self):
+    def teardown_method(self):
         self.storage.close()
 
         for filename in os.listdir(self.tmpdir):
@@ -53,7 +53,7 @@ def test_make_blocks(blocksize):
 
 
 class TestPrecompute(object):
-    def setup(self):
+    def setup_method(self):
         class RunOnceFunction(object):
             def __init__(self):
                 self.previously_seen = set([])

--- a/paths_cli/tests/test_parameters.py
+++ b/paths_cli/tests/test_parameters.py
@@ -62,7 +62,7 @@ class TestArgument(ParameterTest):
 # testing
 
 class ParamInstanceTest(object):
-    def setup(self):
+    def setup_method(self):
         pes = paths.engines.toy.Gaussian(1, [1.0, 1.0], [0.0, 0.0])
         integ = paths.engines.toy.LangevinBAOABIntegrator(0.01, 0.1, 2.5)
         topology = paths.engines.toy.Topology(n_spatial=2, n_atoms=1,
@@ -129,7 +129,7 @@ class ParamInstanceTest(object):
         assert obj.__uuid__ == self.obj.__uuid__
         assert obj == self.obj
 
-    def teardown(self):
+    def teardown_method(self):
         for temp_f in os.listdir(self.tempdir):
             os.remove(os.path.join(self.tempdir, temp_f))
         os.rmdir(self.tempdir)
@@ -137,8 +137,8 @@ class ParamInstanceTest(object):
 
 class TestENGINE(ParamInstanceTest):
     PARAMETER = ENGINE
-    def setup(self):
-        super(TestENGINE, self).setup()
+    def setup_method(self):
+        super(TestENGINE, self).setup_method()
         self.get_arg = {'name': 'engine', 'number': 0, 'only': None,
                         'only-named': None}
         self.obj = self.engine
@@ -162,8 +162,8 @@ class TestENGINE(ParamInstanceTest):
 
 class TestSCHEME(ParamInstanceTest):
     PARAMETER = SCHEME
-    def setup(self):
-        super(TestSCHEME, self).setup()
+    def setup_method(self):
+        super(TestSCHEME, self).setup_method()
         self.get_arg = {'name': 'scheme', 'number': 0, 'only': None,
                         'only-named': None, 'bad-name': 'foo'}
         self.obj = self.scheme
@@ -183,8 +183,8 @@ class TestSCHEME(ParamInstanceTest):
 
 class TestINIT_CONDS(ParamInstanceTest):
     PARAMETER = INIT_CONDS
-    def setup(self):
-        super(TestINIT_CONDS, self).setup()
+    def setup_method(self):
+        super(TestINIT_CONDS, self).setup_method()
         self.traj = make_1d_traj([-0.1, 1.0, 4.4, 7.7, 10.01])
         ensemble = self.scheme.network.sampling_ensembles[0]
         self.sample_set = paths.SampleSet([
@@ -300,8 +300,8 @@ class TestINIT_CONDS(ParamInstanceTest):
 
 class TestINIT_SNAP(ParamInstanceTest):
     PARAMETER = INIT_SNAP
-    def setup(self):
-        super(TestINIT_SNAP, self).setup()
+    def setup_method(self):
+        super(TestINIT_SNAP, self).setup_method()
         traj = make_1d_traj([1.0, 2.0])
         self.other_snap = traj[0]
         self.init_snap = traj[1]
@@ -360,8 +360,8 @@ class MultiParamInstanceTest(ParamInstanceTest):
 
 class TestCVS(MultiParamInstanceTest):
     PARAMETER = CVS
-    def setup(self):
-        super(TestCVS, self).setup()
+    def setup_method(self):
+        super(TestCVS, self).setup_method()
         self.get_arg = {'name': ["x"], 'number': [0]}
         self.obj = self.cv
 
@@ -372,8 +372,8 @@ class TestCVS(MultiParamInstanceTest):
 
 class TestSTATES(MultiParamInstanceTest):
     PARAMETER = STATES
-    def setup(self):
-        super(TestSTATES, self).setup()
+    def setup_method(self):
+        super(TestSTATES, self).setup_method()
         self.get_arg = {'name': ["A"], 'number': [0]}
         self.obj = self.state_A
 
@@ -411,32 +411,32 @@ class TestMULTI_VOLUME(TestSTATES, MULTITest):
 
 class TestMULTI_ENGINE(MULTITest):
     PARAMETER = MULTI_ENGINE
-    def setup(self):
-        super(TestMULTI_ENGINE, self).setup()
+    def setup_method(self):
+        super(TestMULTI_ENGINE, self).setup_method()
         self.get_arg = {'name': ["engine"], 'number': [0]}
         self.obj = self.engine
 
 
 class TestMulti_NETWORK(MULTITest):
     PARAMETER = MULTI_NETWORK
-    def setup(self):
-        super(TestMulti_NETWORK, self).setup()
+    def setup_method(self):
+        super(TestMulti_NETWORK, self).setup_method()
         self.get_arg = {'name': ['network'], 'number': [0]}
         self.obj = self.network
 
 
 class TestMULTI_SCHEME(MULTITest):
     PARAMETER = MULTI_SCHEME
-    def setup(self):
-        super(TestMULTI_SCHEME, self).setup()
+    def setup_method(self):
+        super(TestMULTI_SCHEME, self).setup_method()
         self.get_arg = {'name': ['scheme'], 'number': [0]}
         self.obj = self.scheme
 
 
 class TestMULTI_TAG(MULTITest):
     PARAMETER = MULTI_TAG
-    def setup(self):
-        super(TestMULTI_TAG, self).setup()
+    def setup_method(self):
+        super(TestMULTI_TAG, self).setup_method()
         self.obj = make_1d_traj([1.0, 2.0, 3.0])
         self.get_arg = {'name': ['traj']}
 

--- a/paths_cli/tests/test_plugin_management.py
+++ b/paths_cli/tests/test_plugin_management.py
@@ -17,7 +17,7 @@ def test_ops_plugin():
     assert plugin.requires_lib == (1, 2)
 
 class PluginLoaderTest(object):
-    def setup(self):
+    def setup_method(self):
         self.expected_section = {'pathsampling': "Simulation",
                                  'contents': "Miscellaneous"}
 
@@ -51,8 +51,8 @@ class PluginLoaderTest(object):
 
 
 class TestFilePluginLoader(PluginLoaderTest):
-    def setup(self):
-        super().setup()
+    def setup_method(self):
+        super().setup_method()
         # use our own commands dir as a file-based plugin
         cmds_init = pathlib.Path(paths_cli.commands.__file__).resolve()
         self.commands_dir = cmds_init.parent
@@ -64,8 +64,8 @@ class TestFilePluginLoader(PluginLoaderTest):
 
 
 class TestNamespacePluginLoader(PluginLoaderTest):
-    def setup(self):
-        super().setup()
+    def setup_method(self):
+        super().setup_method()
         self.namespace = "paths_cli.commands"
         self.loader = NamespacePluginLoader(self.namespace, OPSCommandPlugin)
         self.plugin_type = 'namespace'

--- a/paths_cli/tests/test_utils.py
+++ b/paths_cli/tests/test_utils.py
@@ -1,7 +1,7 @@
 from paths_cli.utils import *
 
 class TestOrderedSet:
-    def setup(self):
+    def setup_method(self):
         self.set = OrderedSet(['a', 'b', 'a', 'c', 'd', 'c', 'd'])
 
     def test_len(self):

--- a/paths_cli/tests/wizard/test_helper.py
+++ b/paths_cli/tests/wizard/test_helper.py
@@ -16,7 +16,7 @@ def test_force_exit():
         force_exit("foo", None)
 
 class TestEvalHelperFunc:
-    def setup(self):
+    def setup_method(self):
         self.param_helper = {
             'str': "help_string",
             'method': lambda help_args, context: f"help_{help_args}"
@@ -39,7 +39,7 @@ class TestEvalHelperFunc:
         assert help_func("eval") == _LONG_EVAL_HELP
 
 class TestHelper:
-    def setup(self):
+    def setup_method(self):
         self.helper = Helper(help_func=lambda s, ctx: s)
 
     def test_help_string(self):

--- a/paths_cli/tests/wizard/test_parameters.py
+++ b/paths_cli/tests/wizard/test_parameters.py
@@ -15,7 +15,7 @@ class TestWizardParameter:
     def _reverse(string):
         return "".join(reversed(string))
 
-    def setup(self):
+    def setup_method(self):
         self.parameter = WizardParameter(
             name='foo',
             ask="How should I {do_what}?",
@@ -79,7 +79,7 @@ class TestWizardParameter:
 
 
 class TestFromWizardPrerequisite:
-    def setup(self):
+    def setup_method(self):
         # For this model, user input should be a string that represents an
         # integer. The self._create method repeats the input string, e.g.,
         # "1" => "11", and wraps the result in self.Wrapper. This is the

--- a/paths_cli/tests/wizard/test_plugin_classes.py
+++ b/paths_cli/tests/wizard/test_plugin_classes.py
@@ -80,7 +80,7 @@ def test_get_text_from_context(context, instance, default, expected):
 
 
 class TestWizardObjectPlugin:
-    def setup(self):
+    def setup_method(self):
         self.plugin = WizardObjectPlugin(
             name="foo",
             category="foo_category",
@@ -133,7 +133,7 @@ class TestWizardParameterObjectPlugin:
             self.foo = foo
             self.bar = bar
 
-    def setup(self):
+    def setup_method(self):
         self.parameters = [
             WizardParameter(name="foo",
                             ask="Gimme a foo!",
@@ -191,7 +191,7 @@ class TestWizardParameterObjectPlugin:
 
 
 class TestCategoryHelpFunc:
-    def setup(self):
+    def setup_method(self):
         self.category = WrapCategory("foo", "ask foo")
         self.plugin = WizardObjectPlugin(
             name="bar",
@@ -247,7 +247,7 @@ class TestCategoryHelpFunc:
 
 
 class TestWrapCategory:
-    def setup(self):
+    def setup_method(self):
         self.wrapper = WrapCategory("foo", "ask foo", intro="intro_foo")
         self.plugin_no_format = WizardObjectPlugin(
             name="bar",

--- a/paths_cli/tests/wizard/test_wizard.py
+++ b/paths_cli/tests/wizard/test_wizard.py
@@ -57,7 +57,7 @@ class MockStorage:
 
 
 class TestWizard:
-    def setup(self):
+    def setup_method(self):
         self.wizard = Wizard([])
 
     def test_initialization(self):


### PR DESCRIPTION
Problems with CI that this will fix:

1. We're way behind on Python versions; this brings the CLI in line with versions tested in the OPS library
2. We're having a problem with the build process; seems something was problematic with the pip install stack (I think this was fixed by not trying to support older Pythons)
4. Tests needed to be updated from `setup`/`teardown` to `setup_method`/`teardown_method`
5. Updated CodeCov, as it didn't seem to allow uploads without token.

This wasn't as bad as I feared!