### PR TITLE
Update badge; copyright in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2022 David W.H. Swenson and contributors
+Copyright (c) 2019-2024 David W.H. Swenson and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Tests](https://github.com/openpathsampling/openpathsampling-cli/workflows/Tests/badge.svg)](https://github.com/openpathsampling/openpathsampling-cli/actions?query=workflow%3ATests)
+[![Tests](https://github.com/openpathsampling/openpathsampling-cli/actions/workflows/test-suite.yml/badge.svg)](https://github.com/openpathsampling/openpathsampling-cli/actions/workflows/test-suite.yml)
 [![Documentation Status](https://readthedocs.org/projects/openpathsampling-cli/badge/?version=latest)](https://openpathsampling-cli.readthedocs.io/en/latest/?badge=latest)
 [![Coverage Status](https://codecov.io/gh/openpathsampling/openpathsampling-cli/branch/master/graph/badge.svg)](https://codecov.io/gh/openpathsampling/openpathsampling-cli)
 [![Maintainability](https://api.codeclimate.com/v1/badges/0d1ee29e1a05cfcdc01a/maintainability)](https://codeclimate.com/github/openpathsampling/openpathsampling-cli/maintainability)


### PR DESCRIPTION
Apparently our CI badge here is out of date, and therefore giving bad status. Also, the copyright notice needed to be touched.

Should have no effect on code. I'll merge on green; don't see a need for review on this.