### PR TITLE
Add help to compile; make it visible in CLI help

### DIFF
--- a/paths_cli/cli.py
+++ b/paths_cli/cli.py
@@ -61,7 +61,8 @@ class OpenPathSamplingCLI(click.MultiCommand):
         return self._get_command.get(name)
 
     def format_commands(self, ctx, formatter):
-        sec_order = ['Simulation', 'Analysis', 'Miscellaneous', 'Workflow']
+        sec_order = ["Simulation Setup", 'Simulation', 'Analysis',
+                     'Miscellaneous', 'Workflow']
         for sec in sec_order:
             cmds = self._sections.get(sec, [])
             rows = []

--- a/paths_cli/commands/compile.py
+++ b/paths_cli/commands/compile.py
@@ -68,10 +68,18 @@ def register_installed_plugins():
 
 @click.command(
     'compile',
+    short_help="compile a description of OPS objects into a database",
 )
 @click.argument('input_file')
 @OUTPUT_FILE.clicked(required=True)
 def compile_(input_file, output_file):
+    """Compile JSON or YAML description of OPS objects into a database.
+
+    INPUT_FILE is a JSON or YAML file that describes OPS simulation
+    objects (e.g., MD engines, state volumes, etc.). The output will be an
+    OPS database containing those objects, which can be used as the input to
+    many other CLI subcommands.
+    """
     loader = select_loader(input_file)
     with open(input_file, mode='r') as f:
         dct = loader(f)
@@ -87,7 +95,7 @@ def compile_(input_file, output_file):
 
 PLUGIN = OPSCommandPlugin(
     command=compile_,
-    section="Debug",
+    section="Miscellaneous",
     requires_ops=(1, 0),
     requires_cli=(0, 3)
 )

--- a/paths_cli/commands/compile.py
+++ b/paths_cli/commands/compile.py
@@ -95,7 +95,7 @@ def compile_(input_file, output_file):
 
 PLUGIN = OPSCommandPlugin(
     command=compile_,
-    section="Miscellaneous",
+    section="Simulation Setup",
     requires_ops=(1, 0),
     requires_cli=(0, 3)
 )

--- a/paths_cli/compiling/_gendocs/docs_generator.py
+++ b/paths_cli/compiling/_gendocs/docs_generator.py
@@ -54,7 +54,7 @@ class DocsGenerator:
         rst = f".. _compiling--{category_plugin.label}:\n\n"
         rst += f"{cat_info.header}\n{'=' * len(str(cat_info.header))}\n\n"
         if cat_info.description:
-            rst += cat_info.description + "\n\n"
+            rst += cat_info.description + "The following types are available:\n\n"
         rst += ".. contents:: :local:\n\n"
         for obj in category_plugin.type_dispatch.values():
             rst += self.generate_plugin_rst(

--- a/paths_cli/tests/compiling/_gendocs/test_docs_generator.py
+++ b/paths_cli/tests/compiling/_gendocs/test_docs_generator.py
@@ -50,7 +50,7 @@ class TestDocsGenerator:
             ".. _compiling--category:",
             "Header\n======\n",
             ".. contents:: :local:",
-            "\ncategory_desc\n",
+            "\ncategory_descThe following types are available:\n",
         ]
 
     @pytest.mark.parametrize('param_type', ['req', 'opt'])


### PR DESCRIPTION
I'm going to leave the wizard hidden for the 0.3 release, but compile is one of the marquee features for this release.

To-do:

- ~Needs to link to the page in core docs that discusses default options and how to generate documentation for all installed options.~

EDIT: To clarify here, I have made the decision that the Wizard, while a lot of fun, isn't mature enough or well-designed enough to be something I want to commit to maintaining. It also isn't an approach that we should put much effort into expanding/maturing (there are better ways to be user friendly.) It was originally a bit of a response to people who kept saying that OPS was too hard to use because it required working in a Jupyter notebook. Frankly, I think there are better solutions to make that response.

However, I totally intend to leave it in as an easter egg for anyone who finds it, because I find it hilarious. Especially the error demon.