### PR TITLE
Silence annoying pymbar warnings

### DIFF
--- a/paths_cli/cli.py
+++ b/paths_cli/cli.py
@@ -94,6 +94,7 @@ def main(log):
         logging.config.fileConfig(log, disable_existing_loggers=False)
     # TODO: if log not given, check for logging.conf in .openpathsampling/
 
+    # TODO: remove when openmmtools doesn't trigger these warnings
     silence_warnings = ['pymbar.mbar_solvers', 'pymbar.timeseries']
     for lname in silence_warnings:
         logger = logging.getLogger(lname)

--- a/paths_cli/cli.py
+++ b/paths_cli/cli.py
@@ -94,6 +94,12 @@ def main(log):
         logging.config.fileConfig(log, disable_existing_loggers=False)
     # TODO: if log not given, check for logging.conf in .openpathsampling/
 
+    silence_warnings = ['pymbar.mbar_solvers', 'pymbar.timeseries']
+    for lname in silence_warnings:
+        logger = logging.getLogger(lname)
+        logger.setLevel(logging.CRITICAL)
+
+
     logger = logging.getLogger(__name__)
     logger.debug("About to run command")  # TODO: maybe log invocation?
 


### PR DESCRIPTION
On importing OpenMMTools (which happens as part of reloading objects), we get some annoying warnings from pymbar. I'd like to try to get this fixed upstream in OpenMMTools, but for now here's a hack that makes it less unpleasant to work with the CLI.