### PR TITLE
SPEC0/NEP29: Add Python 3.12, drop Python 3.9

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -24,12 +24,12 @@ jobs:
     strategy:
       matrix:
         CONDA_PY:
+          - "3.12"
           - "3.11"
           - "3.10"
-          - "3.9"
         INTEGRATIONS: [""]
         include:
-          - CONDA_PY: "3.11"
+          - CONDA_PY: "3.12"
             INTEGRATIONS: 'all-optionals'
 
     steps:

--- a/paths_cli/tests/compiling/test_root_compiler.py
+++ b/paths_cli/tests/compiling/test_root_compiler.py
@@ -247,8 +247,8 @@ def test_register_plugins_unit(foo_compiler_plugin, foo_baz_builder_plugin):
     with patch(BASE + "_register_builder_plugin", Mock()) as builder, \
             patch(BASE + "_register_compiler_plugin", Mock()) as compiler:
         register_plugins([foo_baz_builder_plugin, foo_compiler_plugin])
-        assert builder.called_once_with(foo_baz_builder_plugin)
-        assert compiler.called_once_with(foo_compiler_plugin)
+        builder.assert_called_once_with(foo_baz_builder_plugin)
+        compiler.assert_called_once_with(foo_compiler_plugin)
 
 
 def test_register_plugins_integration(foo_compiler_plugin,

--- a/paths_cli/tests/wizard/test_plugin_classes.py
+++ b/paths_cli/tests/wizard/test_plugin_classes.py
@@ -38,7 +38,7 @@ class TestLoadOPS:
         with mock.patch(patch_loc, mock_load):
             result = loader(wiz)
 
-        assert mock_load.called_once_with(wiz, "foos", "foo")
+        mock_load.assert_called_once_with(wiz, "foos", "foo")
         assert result == "some_object"
 
 


### PR DESCRIPTION
Both [SPEC0](https://scientific-python.org/specs/spec-0000/) and [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy) currently recommend supporting Python versions 3.10, 3.11, and 3.12. Tests here hadn't started on 3.12 and still tested 3.9. This PR just changes the testing matrix.