### PR TITLE
Release 0.3.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = openpathsampling-cli
-version = 0.3.1.dev0
+version = 0.3.1
 # version should end in .dev0 if this isn't to be released
 description = Command line tool for OpenPathSampling
 long_description = file: README.md


### PR DESCRIPTION
This is a minor update to fix a bug in packaging.

## Bugs fixed

* Add `compat/__init__.py` ([#82](https://github.com/openpathsampling/openpathsampling-cli/pull/82))
