### PR TITLE
Add numpy as req in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ python_requires = >= 3.10
 install_requires =
     click
     tqdm
+    numpy
     openpathsampling >= 1.6
 packages = find:
 


### PR DESCRIPTION
This should have been added in 0.3.0, with the compiling subpackage. It has been (and probably will be) fine as a transitive dependency from OpenPathSampling. But there's no reason not to do best practices.

See https://github.com/conda-forge/openpathsampling-cli-feedstock/pull/7#issuecomment-2277019583