### PR TITLE
Convert output of `INIT_CONDS` parameter to list of trajectories

### DIFF
--- a/paths_cli/parameters.py
+++ b/paths_cli/parameters.py
@@ -27,8 +27,6 @@ class InitCondsLoader(OPSStorageLoadMultiple):
             yield obj.trajectory
         elif isinstance(obj, paths.Trajectory):
             yield obj
-        elif isinstance(obj, paths.BaseSnapshot):
-            yield paths.Trajectory([obj])
         elif isinstance(obj, list):
             for o in obj:
                 yield from self._extract_trajectories(o)

--- a/paths_cli/parameters.py
+++ b/paths_cli/parameters.py
@@ -18,7 +18,31 @@ SCHEME = OPSStorageLoadSingle(
     store='schemes',
 )
 
-INIT_CONDS = OPSStorageLoadMultiple(
+class InitCondsLoader(OPSStorageLoadMultiple):
+    def _extract_trajectories(self, obj):
+        import openpathsampling as paths
+        if isinstance(obj, paths.SampleSet):
+            yield from (s.trajectory for s in obj)
+        elif isinstance(obj, paths.Sample):
+            yield obj.trajectory
+        elif isinstance(obj, paths.Trajectory):
+            yield obj
+        elif isinstance(obj, paths.BaseSnapshot):
+            yield paths.Trajectory([obj])
+        elif isinstance(obj, list):
+            for o in obj:
+                yield from self._extract_trajectories(o)
+        else:
+            raise RuntimeError("Unknown initial conditions type: "
+                               f"{obj} (type: {type(obj)}")
+
+    def get(self, storage, names):
+        results = super().get(storage, names)
+        final_results = list(self._extract_trajectories(results))
+        return final_results
+
+
+INIT_CONDS = InitCondsLoader(
     param=Option('-t', '--init-conds', multiple=True,
                  help=("identifier for initial conditions "
                        + "(sample set or trajectory)" + HELP_MULTIPLE)),

--- a/paths_cli/tests/commands/test_equilibrate.py
+++ b/paths_cli/tests/commands/test_equilibrate.py
@@ -11,7 +11,7 @@ import openpathsampling as paths
 def print_test(output_storage, scheme, init_conds, multiplier, extra_steps):
     print(isinstance(output_storage, paths.Storage))
     print(scheme.__uuid__)
-    print(init_conds.__uuid__)
+    print([o.__uuid__ for o in init_conds])
     print(multiplier, extra_steps)
 
 
@@ -31,8 +31,10 @@ def test_equilibrate(tps_fixture):
             ["setup.nc", "-o", "foo.nc"]
         )
         out_str = "True\n{schemeid}\n{condsid}\n1 0\n"
-        expected_output = out_str.format(schemeid=scheme.__uuid__,
-                                         condsid=init_conds.__uuid__)
+        expected_output = out_str.format(
+            schemeid=scheme.__uuid__,
+            condsid=[o.trajectory.__uuid__ for o in init_conds],
+        )
         assert results.exit_code == 0
         assert results.output == expected_output
 

--- a/paths_cli/tests/commands/test_pathsampling.py
+++ b/paths_cli/tests/commands/test_pathsampling.py
@@ -11,7 +11,7 @@ from paths_cli.commands.pathsampling import *
 def print_test(output_storage, scheme, init_conds, n_steps):
     print(isinstance(output_storage, paths.Storage))
     print(scheme.__uuid__)
-    print(init_conds.__uuid__)
+    print([traj.__uuid__ for traj in init_conds])
     print(n_steps)
 
 @patch('paths_cli.commands.pathsampling.pathsampling_main', print_test)
@@ -26,7 +26,8 @@ def test_pathsampling(tps_fixture):
 
         results = runner.invoke(pathsampling, ['setup.nc', '-o', 'foo.nc',
                                                '-n', '1000'])
-        expected_output = (f"True\n{scheme.__uuid__}\n{init_conds.__uuid__}"
+        initcondsid = [samp.trajectory.__uuid__ for samp in init_conds]
+        expected_output = (f"True\n{scheme.__uuid__}\n{initcondsid}"
                            "\n1000\n")
 
         assert results.output == expected_output

--- a/paths_cli/tests/test_parameters.py
+++ b/paths_cli/tests/test_parameters.py
@@ -243,8 +243,8 @@ class TestINIT_CONDS(ParamInstanceTest):
         storage = paths.Storage(filename, mode='r')
         get_type, getter_style = self._parse_getter(getter)
         expected = {
-            'sset': self.sample_set,
-            'traj': self.traj
+            'sset': [s.trajectory for s in self.sample_set],
+            'traj': [self.traj]
         }[get_type]
         get_arg = {
             'name': 'traj',
@@ -277,7 +277,14 @@ class TestINIT_CONDS(ParamInstanceTest):
 
         st = paths.Storage(filename, mode='r')
         obj = INIT_CONDS.get(st, None)
-        assert obj == stored_things[num_in_file - 1]
+        # TODO: fix this for all being trajectories
+        expected = [
+            [self.traj],
+            [s.trajectory for s in self.sample_set],
+            [s.trajectory for s in self.other_sample_set],
+            [s.trajectory for s in self.other_sample_set],
+        ]
+        assert obj == expected[num_in_file - 1]
 
     def test_get_multiple(self):
         filename = self.create_file('number-traj')

--- a/paths_cli/tests/test_parameters.py
+++ b/paths_cli/tests/test_parameters.py
@@ -214,8 +214,12 @@ class TestINIT_CONDS(ParamInstanceTest):
         get_type, getter_style = self._parse_getter(getter)
         main, other = {
             'traj': (self.traj, self.other_traj),
-            'sset': (self.sample_set, self.other_sample_set)
+            'sset': (self.sample_set, self.other_sample_set),
+            'samp': (self.sample_set[0], self.other_sample_set[0]),
         }[get_type]
+        if get_type == 'samp':
+            storage.save(main)
+            storage.save(other)
         if get_type == 'sset':
             storage.save(self.sample_set)
             storage.save(self.other_sample_set)
@@ -231,12 +235,14 @@ class TestINIT_CONDS(ParamInstanceTest):
 
         if other_tag:
             storage.tags[other_tag] = other
+
         storage.close()
         return filename
 
     @pytest.mark.parametrize("getter", [
         'name-traj', 'number-traj', 'tag-final-traj', 'tag-initial-traj',
-        'name-sset', 'number-sset', 'tag-final-sset', 'tag-initial-sset'
+        'name-sset', 'number-sset', 'tag-final-sset', 'tag-initial-sset',
+        'name-samp', 'number-samp',
     ])
     def test_get(self, getter):
         filename = self.create_file(getter)
@@ -244,7 +250,8 @@ class TestINIT_CONDS(ParamInstanceTest):
         get_type, getter_style = self._parse_getter(getter)
         expected = {
             'sset': [s.trajectory for s in self.sample_set],
-            'traj': [self.traj]
+            'traj': [self.traj],
+            'samp': [self.sample_set[0].trajectory],
         }[get_type]
         get_arg = {
             'name': 'traj',
@@ -302,6 +309,18 @@ class TestINIT_CONDS(ParamInstanceTest):
         storage = paths.Storage(filename, 'r')
         with pytest.raises(RuntimeError):
             self.PARAMETER.get(storage, None)
+
+    def test_get_bad_name(self):
+        filename = self._filename("bad_tag")
+        storage = paths.Storage(filename, 'w')
+        storage.save(self.traj)
+        storage.save(self.other_traj)
+        storage.tags['bad_tag'] = "foo"
+        storage.close()
+
+        storage = paths.Storage(filename, 'r')
+        with pytest.raises(RuntimeError, match="initial conditions type"):
+            self.PARAMETER.get(storage, "bad_tag")
 
 
 class TestINIT_SNAP(ParamInstanceTest):

--- a/paths_cli/tests/test_parameters.py
+++ b/paths_cli/tests/test_parameters.py
@@ -277,7 +277,6 @@ class TestINIT_CONDS(ParamInstanceTest):
 
         st = paths.Storage(filename, mode='r')
         obj = INIT_CONDS.get(st, None)
-        # TODO: fix this for all being trajectories
         expected = [
             [self.traj],
             [s.trajectory for s in self.sample_set],


### PR DESCRIPTION
This changes the result of the `INIT_CONDS.get()` method so that it always returns a list of a trajectories. Since this is usually then consumed by `scheme.initial_conditions_from_trajectories`, this approach will always give a workable result. This is an API break, but since the result on the typical consumer is to allow more input types, I'm not concerned with backward compatibility.

The issue was that sometimes, if calling the `INIT_CONDS` parameter multiple times (e.g., `SampleSet` or `Trajectory` objects from different interface sets/interfaces), this would break the input of `scheme.initial_conditions_from_trajectories`. While it might be good to also modify that function to allow multiple `SampleSet`s and a mixture of types in the input list, it seemed easier to make that change in the CLI for now. Usually, a Python library-level user has more ability to fix up their input types, whereas a CLI user has no such ability.