### PR TITLE
New command: `bootstrap-init`

### DIFF
--- a/paths_cli/commands/bootstrap_init.py
+++ b/paths_cli/commands/bootstrap_init.py
@@ -1,0 +1,35 @@
+from paths_cli.parameters import (
+    MULTI_INIT_SNAP, MULTI_NETWORK, OUTPUT_FILE, INPUT_FILE
+)
+
+@MULTI_INIT_SNAP.clicked()
+@MULTI_NETWORK.clicked()
+@OUTPUT_FILE.clicked()
+@INPUT_FILE.clicked()
+def bootstrap_init(init_frame, network, output_file, input_file):
+    ...
+
+def _update_init_frames(transitions, init_frames):
+    transition_to_init_frame = {}
+    for transition in transitions:
+        # raise error if not TIS transition
+        transition_to_init_frame[transition] = None
+        for snap in init_frames:
+            if init_frame.initial_state(snap):
+                transition_to_init_frame[transition] = snap
+                break
+    return transition_to_init_frame
+
+
+def bootstrap_init_main(init_frames, networks, output_file):
+    all_transitions = {trans for trans in network.sampling_transitions
+                       for network in networks}
+    trans_to_init_frame = _update_init_frames(all_transitions, init_frames)
+    missing = {trans for trans, frame in trans_to_init_frame.items()
+               if frame is None}
+    # TODO warn about missing initial frames
+    found = set(trans_to_init_frame) - missing
+    completed = set()
+    for transition in found:
+        ...
+

--- a/paths_cli/commands/bootstrap_init.py
+++ b/paths_cli/commands/bootstrap_init.py
@@ -1,35 +1,82 @@
+import click
+from paths_cli import OPSCommandPlugin
 from paths_cli.parameters import (
-    MULTI_INIT_SNAP, MULTI_NETWORK, OUTPUT_FILE, INPUT_FILE
+    INIT_SNAP, MULTI_NETWORK, OUTPUT_FILE, INPUT_FILE, ENGINE
+)
+from paths_cli.param_core import OPSStorageLoadSingle, Option
+
+INIT_STATE = OPSStorageLoadSingle(
+    param=Option("--initial-state", help="initial state"),
+    store='volumes'
+)
+FINAL_STATE = OPSStorageLoadSingle(
+    param=Option("--final-state", help="final state"),
+    store='volumes'
 )
 
-@MULTI_INIT_SNAP.clicked()
+@click.command(
+    "bootstrap-init",
+    short_help="TIS interface set initial trajectories from a snapshot",
+)
+@INIT_STATE.clicked(required=True)
+@FINAL_STATE.clicked(required=True)
+@INIT_SNAP.clicked()
 @MULTI_NETWORK.clicked()
+@ENGINE.clicked()
 @OUTPUT_FILE.clicked()
 @INPUT_FILE.clicked()
-def bootstrap_init(init_frame, network, output_file, input_file):
-    ...
+def bootstrap_init(init_state, final_state, network, engine, init_snap,
+                   output_file, input_file):
+    """Use ``FullBootstrapping`` to create initial conditions for TIS.
 
-def _update_init_frames(transitions, init_frames):
-    transition_to_init_frame = {}
-    for transition in transitions:
-        # raise error if not TIS transition
-        transition_to_init_frame[transition] = None
-        for snap in init_frames:
-            if init_frame.initial_state(snap):
-                transition_to_init_frame[transition] = snap
-                break
-    return transition_to_init_frame
+    This approach starts from a snapshot, runs MD to generate an initial
+    path for the innermost ensemble, and then performs one-way shooting
+    moves within each ensemble until the next ensemble as reached. This
+    continues until all ensembles have valid trajectories.
+
+    Note that intermediate sampling in this is not saved to disk.
+    """
+    storage = INPUT_FILE.get(input_file)
+    network = MULTI_NETWORK.get(storage, network)
+    init_state = INIT_STATE.get(storage, init_state)
+    final_state = FINAL_STATE.get(storage, final_stage)
+    transition = network.transitions[(init_state, final_state)]
+    bootstrap_init_main(
+        init_frame=INIT_SNAP.get(storage, init_snap),
+        network=network,
+        engine=engine,
+        transition=transition,
+        output_storage=OUTPUT_FILE.get(output_file)
+    )
 
 
-def bootstrap_init_main(init_frames, networks, output_file):
-    all_transitions = {trans for trans in network.sampling_transitions
-                       for network in networks}
-    trans_to_init_frame = _update_init_frames(all_transitions, init_frames)
-    missing = {trans for trans, frame in trans_to_init_frame.items()
-               if frame is None}
-    # TODO warn about missing initial frames
-    found = set(trans_to_init_frame) - missing
-    completed = set()
-    for transition in found:
-        ...
+def bootstrap_init_main(init_frame, network, engine, transition,
+                        output_storage):
+    all_states = set(network.initial_states) | set(network.final_states)
+    allowed_states = {transition.initial_state, transition.final_state}
+    forbidden_states = list(all_states - allowed_states)
+    try:
+        extra_ensembles = network.ms_outers
+    except KeyError:
+        extra_ensembles = None
 
+    bootstrapper = paths.FullBootstrapping(
+        transition=transition,
+        snaphot=init_frame,
+        engine=engine,
+        forbidden_states=forbidden_states,
+        extra_ensembles=extra_ensembles,
+    )
+    init_conds = bootstrapper.run()
+    if output_storage:
+        output_storage.tags['final_conditions'] = init_conds
+
+    return init_conds, bootstrapper
+
+
+PLUGIN = OPSCommandPlugin(
+    command=bootstrap_init,
+    section="Simulation",
+    requires_ops=(1, 0),
+    requires_cli=(0, 4),
+)

--- a/paths_cli/parameters.py
+++ b/paths_cli/parameters.py
@@ -109,15 +109,6 @@ MULTI_SCHEME = OPSStorageLoadNames(
     store='schemes'
 )
 
-MULTI_INIT_SNAP = OPSStorageLoadMultiple(
-    param=Option('-f', '--init-frame',
-                 help="identifier for potential initial snapshots"),
-    store='snapshots',
-    value_strategies=[GetByName('tags'), GetByNumber('snapshots')],
-    none_strategies=[GetOnlySnapshot(),
-                     GetPredefinedName('tags', 'initial_snapshot')]
-)
-
 INPUT_FILE = StorageLoader(
     param=Argument('input_file',
                    type=click.Path(exists=True, readable=True)),

--- a/paths_cli/parameters.py
+++ b/paths_cli/parameters.py
@@ -87,6 +87,15 @@ MULTI_SCHEME = OPSStorageLoadNames(
     store='schemes'
 )
 
+MULTI_INIT_SNAP = OPSStorageLoadMultiple(
+    param=Option('-f', '--init-frame',
+                 help="identifier for potential initial snapshots"),
+    store='snapshots',
+    value_strategies=[GetByName('tags'), GetByNumber('snapshots')],
+    none_strategies=[GetOnlySnapshot(),
+                     GetPredefinedName('tags', 'initial_snapshot')]
+)
+
 INPUT_FILE = StorageLoader(
     param=Argument('input_file',
                    type=click.Path(exists=True, readable=True)),

--- a/paths_cli/tests/commands/test_bootstrap_init.py
+++ b/paths_cli/tests/commands/test_bootstrap_init.py
@@ -1,0 +1,65 @@
+import pytest
+from click.testing import CliRunner
+from unittest.mock import patch
+
+from paths_cli.commands.bootstrap_init import *
+import openpathsampling as paths
+
+def print_test(init_frame, network, engine, transition, output_storage):
+    print(init_frame.__uuid__)
+    print(network.__uuid__)
+    print(engine.__uuid__)
+    # apparently transition UUID isn't preserved, but these are?
+    print(transition.stateA.__uuid__)
+    print(transition.stateB.__uuid__)
+    print([e.__uuid__ for e in transition.ensembles])
+    print(isinstance(output_storage, paths.Storage))
+
+@patch('paths_cli.commands.bootstrap_init.bootstrap_init_main', print_test)
+def test_bootstrap_init(tis_fixture):
+    scheme, network, engine, init_conds = tis_fixture
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        storage = paths.Storage("setup.nc", 'w')
+        storage.save(init_conds)
+        for obj in tis_fixture:
+            storage.save(obj)
+
+        storage.tags["init_snap"] = init_conds[0][0]
+        storage.close()
+
+        results = runner.invoke(bootstrap_init, [
+            'setup.nc',
+            '-o', 'foo.nc',
+            '--initial-state', "A",
+            '--final-state', "B",
+            '--init-frame', 'init_snap',
+        ])
+
+        transitions = list(network.transitions.values())
+        assert len(transitions) == 1
+        transition = transitions[0]
+        stateA = transition.stateA
+        stateB = transition.stateB
+        ensembles = transition.ensembles
+
+        expected_output = (
+            f"{init_conds[0][0].__uuid__}\n{network.__uuid__}\n"
+            f"{engine.__uuid__}\n"
+            f"{stateA.__uuid__}\n{stateB.__uuid__}\n"
+            f"{[e.__uuid__ for e in ensembles]}\n"
+            "True\n"
+        )
+        assert results.exit_code == 0
+        assert results.output == expected_output
+
+
+def test_bootstrap_init_main(tis_fixture, tmp_path):
+    scheme, network, engine, init_conds = tis_fixture
+    init_frame = init_conds[0][0]
+    assert len(network.transitions) == 1
+    transition = list(network.transitions.values())[0]
+    output_storage = paths.Storage(tmp_path / "output.nc", mode='w')
+    init_conds, bootstrapper = bootstrap_init_main(init_frame, network,
+                                                   engine, transition,
+                                                   output_storage)

--- a/paths_cli/tests/conftest.py
+++ b/paths_cli/tests/conftest.py
@@ -58,3 +58,11 @@ def tis_network(cv_and_states):
                                           [0.0, 0.1, 0.2])
     network = paths.MISTISNetwork([(state_A, interfaces, state_B)])
     return network
+
+@pytest.fixture
+def tis_fixture(flat_engine, tis_network, transition_traj):
+    paths.InterfaceSet._reset()
+    scheme = paths.DefaultScheme(network=tis_network,
+                                 engine=flat_engine)
+    init_conds = scheme.initial_conditions_from_trajectories(transition_traj)
+    return (scheme, tis_network, flat_engine, init_conds)


### PR DESCRIPTION
This provides a CLI interface for the `FullBootstrap` initialization from OpenPathSampling core, which is used in the MSTIS/MISTIS OPS example notebooks.