### PR TITLE
CV Mode from CLI

### DIFF
--- a/paths_cli/commands/pathsampling.py
+++ b/paths_cli/commands/pathsampling.py
@@ -3,7 +3,8 @@ import click
 
 from paths_cli import OPSCommandPlugin
 from paths_cli.parameters import (
-    INPUT_FILE, OUTPUT_FILE, INIT_CONDS, SCHEME, N_STEPS_MC
+    INPUT_FILE, OUTPUT_FILE, INIT_CONDS, SCHEME, N_STEPS_MC,
+    SIMULATION_CV_MODE,
 )
 
 
@@ -16,9 +17,12 @@ from paths_cli.parameters import (
 @SCHEME.clicked(required=False)
 @INIT_CONDS.clicked(required=False)
 @N_STEPS_MC
-def pathsampling(input_file, output_file, scheme, init_conds, nsteps):
+@SIMULATION_CV_MODE.clicked()
+def pathsampling(input_file, output_file, scheme, init_conds, nsteps,
+                 cv_mode):
     """General path sampling, using setup in INPUT_FILE"""
     storage = INPUT_FILE.get(input_file)
+    SIMULATION_CV_MODE(storage, cv_mode)
     pathsampling_main(output_storage=OUTPUT_FILE.get(output_file),
                       scheme=SCHEME.get(storage, scheme),
                       init_conds=INIT_CONDS.get(storage, init_conds),


### PR DESCRIPTION
OPS (SimStore) CVs have several ways the can get the value for a given input object: (1) the can evaluate the function; (2) they can find the result in a memory cache; (3) they can find the result in an on-disk cache.

The order in which they attempt these define the "mode" of the CV:

* `analysis`: first memory cache, then disk cache, then evaluate
* `production`: first memory cache, the evaluate
* `no-caching`: always evaluate

This PR allows a CLI interface to specify these behaviors. In particular, this might be useful for users who don't want to save CVs to disk for cheap CVs, like in toy models.

This also includes usage of this in the `pathsampling` command. In principle, it can come to other commands pretty easily in the future.